### PR TITLE
[QJ5-28] 헤더 컴포넌트 마크업 및 디자인

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { pretendard } from "@/fonts";
 
 import "./globals.css";
+import Header from "@/components/layout/Header";
 
 export default function RootLayout({
   children,
@@ -9,7 +10,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" className={pretendard.className}>
-      <body>{children}</body>
+      <body>
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { Button } from "../common";
+import LightLogo from "@/public/icons/light_logo.svg";
+import DarkLogo from "@/public/icons/dark_logo.svg";
+
+const Header = () => {
+  const router = usePathname();
+  const [isLogin, setIsLogin] = useState(true); // 로그인 여부 로직 처리
+
+  const buttonList = [
+    { text: "발견", url: "/discovery" },
+    { text: "뉴스", url: "/news" },
+    { text: "관심종목", url: "/mystock" },
+    { text: "마이페이지", url: "/mypage" },
+  ];
+
+  return (
+    <header className="h-[8rem] w-full px-[12rem] py-[1rem]">
+      <div className="flex_row h-full w-full justify-between">
+        <div className="flex_row h-full">
+          <Link href="/">{router === "/" && !isLogin ? <LightLogo /> : <DarkLogo />}</Link>
+          {isLogin && (
+            <nav className="flex_row_center ml-[2rem] h-full">
+              {buttonList.map((item) => (
+                <Link
+                  key={item.text}
+                  href={item.url}
+                  className={`body_3 flex_row_center h-full w-[16rem] ${item.url === router && "font-bold"} text-navy-900`}
+                >
+                  {item.text}
+                </Link>
+              ))}
+            </nav>
+          )}
+        </div>
+        {isLogin && (
+          <Button variant="textButton" size="sm" bgColor="bg-white" className="body_5 w-[10.2rem] font-medium">
+            로그아웃
+          </Button>
+        )}
+      </div>
+    </header>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
## 📌 기능 설명

레이아웃 헤더 UI 구현

## 📌 구현 내용

- 피그마에 디자인된 사항으로 헤더 마크업을 구현했습니다.
- 간단한 라우터 이동만 구현했습니다.
- 추후 로그인 로직을 넣으면 됩니다.

## 📌 구현 결과

- 로그인 X, 메인 페이지
![image](https://github.com/doksuri5/frontend/assets/78673090/498b33c1-2805-458e-9d9e-5cf3435c98fa)

- 로그인 O, 메인 페이지
![image](https://github.com/doksuri5/frontend/assets/78673090/c95c4c17-286d-48c4-9cd4-68595a54c81b)

- 로그인 O, 그 외 페이지
![image](https://github.com/doksuri5/frontend/assets/78673090/72033516-8bad-42ca-8d8e-cbe594041ed6)


## 📌 논의하고 싶은 점
수정해야 될 부분 있으면 말씀해주세요