### PR TITLE
[QJ5-43] Next에서 SVG 파일 설정 

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,11 +3,26 @@ const nextConfig = {
   images: {
     remotePatterns: [{ protocol: "https", hostname: "imgnews.pstatic.net" }],
   },
-  webpack: (config) => {
-    config.module.rules.push({
-      test: /\.svg$/,
-      use: ["@svgr/webpack"],
-    });
+  webpack(config) {
+    // 기존 svg 파일 불러올 때의 조건
+    const fileLoaderRule = config.module.rules.find((rule) => rule.test?.test?.(".svg"));
+
+    config.module.rules.push(
+      // svg 파일일 경우 아래를 실행
+      {
+        ...fileLoaderRule,
+        test: /\.svg$/i,
+        resourceQuery: { not: /component/ }, // *.svg
+      },
+      // svg 컴포넌트를 사용할 경우 아래를 실행
+      {
+        test: /\.svg$/i,
+        resourceQuery: /component/, // *.svg?component
+        use: ["@svgr/webpack"],
+      },
+    );
+    fileLoaderRule.exclude = /\.svg$/i;
+
     return config;
   },
 };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,8 +4,8 @@ import { useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { Button } from "../common";
-import LightLogo from "@/public/icons/light_logo.svg";
-import DarkLogo from "@/public/icons/dark_logo.svg";
+import LightLogo from "@/public/icons/light_logo.svg?component";
+import DarkLogo from "@/public/icons/dark_logo.svg?component";
 
 const Header = () => {
   const router = usePathname();

--- a/svgr.d.ts
+++ b/svgr.d.ts
@@ -1,0 +1,10 @@
+declare module "*.svg?component" {
+  import { FC, SVGProps } from "react";
+  const content: FC<SVGProps<SVGElement>>;
+  export default content;
+}
+
+declare module "*.svg" {
+  const content: any;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -22,21 +18,10 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@/public/*": [
-        "./public/*"
-      ]
+      "@/*": ["./src/*"],
+      "@/public/*": ["./public/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["svgr.d.ts", "next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 📌 기능 설명

SVG 파일 URL 또는 component로 불러오기 위한 설정 파일 수정

## 📌 구현 내용

SVG 파일을 불러올 때, 
- 파일 자체를 불러와서 Image 태그에 넣는 경우
- SVG 파일을 컴포넌트로 변환해서 컴포넌트 처럼 사용하는 경우

2가지의 방법이 있는데, 사람마다 사용 방법이 다르기 때문에 오류가 발생할 수 있습니다.
구분하기 위해 컴포넌트로 사용하는 경우는 `.svg` 확장자 뒤에 `?component` 접미사를 붙여 앨리어싱을 건너뛰어 기본 내보내기를 사용할 수 있습니다.

**svg 파일을 Image 태그에 src로 넣는 경우**
`import LargeRect from "@/public/icons/card3Rectangle_large.svg";`

**svg 파일을 컴포넌트로 변환해서 사용하는 경우**
`import LightLogo from "@/public/icons/light_logo.svg?component";`

## 📌 구현 결과

1. svg 파일을 Image 태그에 src로 넣는 경우
![image](https://github.com/doksuri5/frontend/assets/78673090/d274e64e-23c6-4092-b530-5e4cd3c331e5)

2. svg 파일을 컴포넌트로 변환해서 사용하는 경우
![image](https://github.com/doksuri5/frontend/assets/78673090/91e01fbf-aa4d-4c0a-9c36-908412e0b41f)


## 📌 논의하고 싶은 점
궁금하신 부분 있으시면 말씀해주세요.!

## 📌 참고자료
- [next.js에서 svgr 사용법 - 공식문서](https://react-svgr.com/docs/next/) (공식 문서에서 좀 더 직관적으로 사용하기 위해 조금 수정했습니다.)
- [vite, react에서 svg 컴포넌트화](https://velog.io/@yoonth95/SVG-%ED%8C%8C%EC%9D%BC-React-Component%EB%A1%9C-%EA%B0%80%EC%A0%B8%EC%98%A4%EA%B8%B0-Vite-TypeScript) (vite에서도 svg를 컴포넌트 하는 방법을 정리한 적이 있긴 합니다.)
  - 이건 홍보 글이에요 신경 쓰지 마세요... 좋아요 눌러주세요 ㅎㅎ

## 이슈 넘버
깃허브 이슈 번호 : #21 
지라 이슈 번호 : QJ5-43