### PR TITLE
[QJ5-32] Modal 공통 컴포넌트 작성

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,16 +45,26 @@
   .caption {
     @apply text-[1.2rem] leading-[1.6rem];
   }
-  .flex_row{
-    @apply flex flex-row items-center
+  .flex_row {
+    @apply flex flex-row items-center;
   }
-  .flex_col{
-    @apply flex flex-col items-center 
+  .flex_col {
+    @apply flex flex-col items-center;
   }
   .flex_row_center {
-    @apply flex flex-row items-center justify-center
+    @apply flex flex-row items-center justify-center;
   }
   .flex_row_col {
-    @apply flex flex-col items-center  justify-center
+    @apply flex flex-col items-center justify-center;
   }
+}
+
+/* 스크롤바 숨기기 유틸리티 클래스 */
+.scrollbar-hidden {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.scrollbar-hidden::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, and Opera */
 }

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,101 @@
+/**
+ * 아래 두 줄의 코드를 사용하여 모달을 조작할 수 있습니다.
+ * const [isOpen, setIsOpen] = useState(false); //현재 모달의 열림 여부
+ * const closeModal = () => setIsOpen(false);  //모달 창 닫기 함수
+ *
+ * panelStyle?: 모달 패널의 스타일 지정. 패딩, 모서리 둥글기, 너비 등을 커스텀 가능
+ *
+ * titleStyle?: 타이틀 폰트 스타일 지정, default는 "heading_3". ex) titleStyle="heading_3"
+ *
+ * isOpen: 모달의 현재 상태(오픈) 여부. ex) isOpen={isOpen}
+ *
+ * onClose: 모달 닫기 함수 등록. ex) onClose={() => setIsOpen(false)}
+ *
+ * title?: 모달 제목, 경고메시지 등을 지정. ex) title="회원 탈퇴"
+ *
+ * children: 모달 내부에 들어갈 내용을 작성
+ *
+ * isIconBtn: true/false로 지정 가능. true로 설정하면, 모달 상단 오른쪽에 x 아이콘이 나타나고 이 아이콘 클릭으로 모달 close 가능, default는 false
+ *
+ */
+
+import { cn } from "@/utils/cn";
+import { Dialog, DialogPanel, DialogTitle, TransitionChild } from "@headlessui/react";
+import { Fragment, ReactNode } from "react";
+import Image from "next/image";
+
+type TModalProps = {
+  panelStyle?: string;
+  titleStyle?: string;
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+  closeIcon?: boolean;
+};
+
+export default function Modal({
+  panelStyle = "px-[10.2rem] py-[8rem] rounded-[3.2rem] w-[32.3rem]",
+  titleStyle = "heading_3",
+  isOpen,
+  onClose,
+  title,
+  children,
+  closeIcon = false,
+}: TModalProps) {
+  return (
+    <Dialog open={isOpen} as="div" className={cn(`relative z-10 focus:outline-none`)} onClose={() => {}}>
+      <TransitionChild
+        as={Fragment}
+        enter="duration-300 ease-out"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
+        leave="duration-200 ease-in"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+      >
+        <div className="fixed inset-0 bg-black bg-opacity-50" />
+      </TransitionChild>
+
+      <div className="fixed inset-0 z-10 w-screen">
+        <div className="flex min-h-full items-center justify-center">
+          <TransitionChild
+            as={Fragment}
+            enter="duration-300 ease-out"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="duration-200 ease-in"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <DialogPanel
+              transition
+              className={cn(
+                `${panelStyle} scrollbar-hidden max-h-[92vh] transform items-center overflow-y-scroll bg-grayscale-0 transition-all duration-300 ease-out`,
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex-grow text-center">
+                  <DialogTitle as="h3" className={cn(`${titleStyle} font-bold text-grayscale-900`)}>
+                    {title}
+                  </DialogTitle>
+                </div>
+                {closeIcon && (
+                  <Image
+                    src={"/icons/close_icon.svg"}
+                    alt="close"
+                    width={48}
+                    height={48}
+                    className="cursor-pointer"
+                    onClick={onClose}
+                  />
+                )}
+              </div>
+              <div>{children}</div>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -10,5 +10,20 @@ import NewsList from "./List/NewsList";
 import StockItem from "./List/StockItem";
 import Toggle from "./Toggle";
 import CheckBox from "./CheckBox";
+import Modal from "./Modal";
 
-export { Button, Caption, Card, Dropdown, Input, Label, FindNews, NewsItem, NewsList, StockItem, Toggle, CheckBox };
+export {
+  Button,
+  Caption,
+  Card,
+  Dropdown,
+  Input,
+  Label,
+  FindNews,
+  NewsItem,
+  NewsList,
+  StockItem,
+  Toggle,
+  CheckBox,
+  Modal,
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -62,6 +62,8 @@ const config: Config = {
       fontFamily: {
         pretendard: ["var(--font-pretendard)"],
       },
+      //스크롤바 숨기기
+      scrollbar: ["hidden"],
     },
   },
   plugins: [


### PR DESCRIPTION
## 📌 기능 설명

- [x] Modal 컴포넌트 구현

## 📌 구현 내용

화면 UI 작성에 사용되는 Modal을 구현했습니다.

## 📌 구현 결과

### 모달 예시
<details>
<summary><b>예시 코드</b></summary>
<div markdown="1">

```
"use client";

import { Dropdown, Modal, Button } from "@/components/common";
import { Input } from "@/components/common/Input";
import { useState } from "react";

export default function Home() {
  const [isOpen, setIsOpen] = useState(false);

  const closeModal = () => setIsOpen(false);

  const onChangeSelect = () => {};
  return (
    <>
      <h1 className="bg-background-100">Home Component</h1>
      <button className="rounded-[.8rem] bg-blue-700 px-4 py-2 text-white" onClick={() => setIsOpen(true)}>
        모달 열기
      </button>
      <Modal
        panelStyle="px-[10.2rem] py-[8rem] rounded-[3.2rem] w-[59rem]"
        isOpen={isOpen}
        onClose={() => setIsOpen(false)}
        title="회원 탈퇴"
        titleStyle="heading_3"
        closeIcon={true}
      >
        <div className="mt-[4rem] flex flex-col gap-[1.6rem]">
          <Dropdown
            label="회원탈퇴 사유"
            placeholder="회원가입 사유"
            options={[{ value: "otherService", text: "다른 서비스가 더 좋아서" }]}
            selected={{ value: "otherService", text: "다른 서비스가 더 좋아서" }}
            setSelected={onChangeSelect}
          />
          <Input labelName="비밀번호 입력" />
          <div className="flex flex-row justify-center gap-[1rem]">
            <Button variant="textButton" size="md" bgColor="bg-navy-900" className="w-[15.7rem]">
              {"안녕"}
            </Button>
            <Button
              variant="textButton"
              size="md"
              bgColor="bg-grayscale-300"
              className="w-[15.7rem]"
              onClick={closeModal}
            >
              {"닫기"}
            </Button>
          </div>
        </div>
      </Modal>
    </>
  );
}
```
</div>
</details>
<img src="https://github.com/doksuri5/frontend/assets/51500821/e6fdfe5d-9ec6-4c3b-b3d2-11bf25cfd04c"  width="600" />

### props
```
/**
 * 아래 두 줄의 코드를 사용하여 모달을 조작할 수 있습니다.
 * const [isOpen, setIsOpen] = useState(false); //현재 모달의 열림 여부
 * const closeModal = () => setIsOpen(false);  //모달 창 닫기 함수
 *
 * panelStyle?: 모달 패널의 스타일 지정. 패딩, 모서리 둥글기, 너비 등을 커스텀 가능
 *
 * titleStyle?: 타이틀 폰트 스타일 지정, default는 "heading_3". ex) titleStyle="heading_3"
 *
 * isOpen: 모달의 현재 상태(오픈) 여부. ex) isOpen={isOpen}
 *
 * onClose: 모달 닫기 함수 등록. ex) onClose={() => setIsOpen(false)}
 *
 * title?: 모달 제목, 경고메시지 등을 지정. ex) title="회원 탈퇴"
 *
 * children: 모달 내부에 들어갈 내용을 작성
 *
 * isIconBtn: true/false로 지정 가능. true로 설정하면, 모달 상단 오른쪽에 x 아이콘이 나타나고 이 아이콘 클릭으로 모달 close 가능, default는 false
 *
 */
```

### 모달 내부 스크롤
![Animation](https://github.com/doksuri5/frontend/assets/51500821/5d606c0a-6695-41c6-b889-576bac65ef97)
모달 내부 컨텐츠의 길이가 길어질 경우를 대비해 모달 내부에 스크롤을 달고, 심미성을 고려해 스크롤을 숨김 처리하였습니다.

### 전체 화면
![Animation11](https://github.com/doksuri5/frontend/assets/51500821/60e60207-02c8-4489-8cbd-8571d093662e)
백드롭 클릭 시에는 모달창이 닫히지 않게 설정했습니다. 
관련해서는 아래 `논의하고 싶은 점`에 추가하겠습니다.


## 📌 논의하고 싶은 점

기존에는 닫기 버튼 이외 백드롭(모달 외부 배경화면), 키보드 esc 버튼 클릭 시 모달이 닫히도록 구현했습니다.
하지만 그렇게 구현을 한다면 아래와 같은 2가지의 단점이 존재합니다. 

1. 모달을 alert 창으로 사용 시, 사용자가 실수로 백드롭을 클릭해 창이 닫히면 alert 창 내부의 중요한 정보를 확인하지 못하게 될 수 있습니다.
2. 유저의 데이터 입력이 필요한 작업을 모달에서 진행할 시, 사용자가 실수로 모달 외부를 클릭하면 모달이 닫히면서 입력 데이터가 휘발될 수 있습니다.

2번과 관련해 노아님께서 병렬 라우팅과 인터셉팅 라우트를 사용해 모달을 만드는 방법을 알려주셨습니다.
https://nextjs.org/docs/app/building-your-application/routing/parallel-routes#modals
해당 방식은 Next.js의 병렬 라우팅 기능을 활용하여 모달을 위한 별도의 경로를 설정하고, 인터셉트 라우트를 이용하여 모달이 열릴 때 필요한 데이터를 사전에 가져오는 방식입니다.
위와 같은 방법으로 모달을 구현 시, 모달의 컨텍스트가 유지되어 사용자의 실수로 모달이 닫혔다가 다시 열렸을 때도 입력 데이터가 사라지지 않고, 그로 인해 사용자 경험을 개선할 수 있습니다.
그 외에도 
> URL을 통한 모달의 콘텐츠 공유가 가능합니다.
> 모달을 닫는 대신 페이지를 새로 고칠 경우 컨텍스트를 유지합니다.
> 뒤로 페이지를 이동하여 모달을 닫을 수 있습니다.
> 앞으로 페이지를 이동하여 모달을 다시 열 수 있습니다.
(https://tinyurl.com/yoxo57tx)

이런 다양한 장점이 있다고 합니다.🤩

하지만 병렬 라우팅을 위해서는 미리 모달을 위한 경로를 설정해주어야 하고, 그러기 위해서는 모달이 사용되는 페이지를 생성해 주어야 했습니다.  페이지 설정을 건드리기 부담스러워서 우선 headless ui로만 작업을 진행했고, 대안점으로 백드롭 클릭 시 모달 close를 막는 방식을 적용했습니다. 

병렬 라우팅과 인터셉팅 라우트를 사용한 모달 작성은 장점이 많아서, headless ui로만 만들어진 지금 모달이 뭔가 기능이 부족하다...! 싶을 때 + 추후 페이지가 모두 만들어졌을 때 시간이 나면 도입해봐도 좋겠다는 생각이 들었습니다.😊

관련해서 궁금하신 것이나 의견이 있으면 알려주세요!