### PR TITLE
design: 루트 레이아웃 최대 너비 1200px 고정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,9 +10,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" className={pretendard.className}>
-      <body className="h-[calc(100vh-8rem)]">
+      <body className="h-[calc(100vh-8rem)] bg-background-100">
         <Header />
-        <main className="relative top-[8rem] m-auto min-h-full w-full bg-background-100 px-[12rem]">{children}</main>
+        <main className="relative top-[8rem] m-auto min-h-full max-w-[120rem]">{children}</main>
       </body>
     </html>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -20,8 +20,8 @@ const Header = () => {
   ];
 
   return (
-    <header className="fixed left-0 top-0 z-50 h-[8rem] w-full bg-white px-[12rem] py-[1rem]">
-      <div className="flex_row h-full w-full justify-between">
+    <header className="flex_row_center fixed left-0 top-0 z-50 h-[8rem] w-full bg-white py-[1rem]">
+      <div className="flex_row h-full w-[120rem] justify-between">
         <div className="flex_row h-full">
           <Link href={MAIN_PATH}>{router === MAIN_PATH && !isLogin ? <LightLogo /> : <DarkLogo />}</Link>
           {isLogin && (


### PR DESCRIPTION
## 📌 기능 설명

루트 레이아웃 최대 너비 고정

## 📌 구현 내용

- 피그마에 디자인된 사항으로 전체 페이지의 화면 구성 최대 너비를 1200px로 고정했습니다.

## 📌 구현 결과

![image](https://github.com/doksuri5/frontend/assets/78673090/b3c6e4a3-7cf2-4c0a-9b03-cc0899796e0a)

## 📌 논의하고 싶은 점

- 반응형으로 바뀌게 되면 고정 값들 수정해야 됩니다.!
