### PR TITLE
[QJ5-34] not found & error & loading 페이지 구현

### DIFF
--- a/src/app/(home)/error.tsx
+++ b/src/app/(home)/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Button } from "@/components/common";
+import Image from "next/image";
+import RefreshIcon from "@/public/icons/refresh_icon.svg?component";
+
+export default function error({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <section className="flex h-screen w-full items-center justify-center">
+      <div className="flex flex-col items-center gap-[1.6rem] rounded-[3.2rem] bg-white px-[8.2rem] py-[8.3rem]">
+        <Image src="/icons/warning_icon.svg" alt="waring icon" width={50} height={50} />
+        <h4 className="heading_4 font-bold">홈에서 에러가 발생했습니다.</h4>
+        <span className="body_3">다시 시도해 주세요.</span>
+        <Button className="px-[16.5rem] py-[1.8rem]" bgColor="bg-navy-900 body_3" onClick={() => reset()}>
+          <RefreshIcon width={20} height={20} />
+          메인으로
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -2,7 +2,6 @@ import { StockItem, Button } from "@/components/common";
 import AIIcon from "@/public/icons/AI_icon.svg?component";
 import Image from "next/image";
 import News from "./news";
-import SimpleRadarChart from "@/components/common/SimpleRadarChart";
 import SimpleReportCard from "./_components/SimpleReportCard";
 
 const dummyDataItems = [
@@ -55,7 +54,7 @@ const dummyDataItems = [
 
 export default function HomePage() {
   return (
-    <main className="flex h-full flex-col gap-10 bg-background-100">
+    <div className="flex h-full flex-col gap-10 bg-background-100">
       <div className="flex gap-4 pt-[4rem]">
         <h1 className="heading_4 font-bold">스팩님의 AI 리포트</h1>
         <Button variant="textButton" bgColor="bg-navy-900" className="h-[4rem] w-[8rem]">
@@ -104,6 +103,6 @@ export default function HomePage() {
         </div>
       </section>
       <News />
-    </main>
+    </div>
   );
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Button } from "@/components/common";
+import Image from "next/image";
+import RefreshIcon from "@/public/icons/refresh_icon.svg?component";
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <html className="h-full w-full">
+      <body className="flex h-full w-full items-center justify-center gap-[3.2rem] bg-background-100">
+        <div className="flex flex-col items-center gap-[1.6rem] rounded-[3.2rem] bg-white px-[8.2rem] py-[8.3rem]">
+          <Image src="/icons/warning_icon.svg" alt="waring icon" width={50} height={50} />
+          <h4 className="heading_4 font-bold">에러가 발생했습니다.</h4>
+          <span className="body_3">에러 코드: {error.digest}</span>
+          <Button className="px-[16.5rem] py-[1.8rem]" bgColor="bg-navy-900 body_3" onClick={() => reset()}>
+            <RefreshIcon width={20} height={20} />
+            다시 시도
+          </Button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,11 @@
+import Spinner from "@/components/common/Spinner";
+
+export default function Loading() {
+  return (
+    <section className="flex h-screen items-center justify-center">
+      <div className="relative h-[25.6rem] w-[25.6rem] rounded-[3.2rem] bg-white p-[8rem]">
+        <Spinner />
+      </div>
+    </section>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Button } from "@/components/common";
+import Image from "next/image";
+import RefreshIcon from "@/public/icons/refresh_icon.svg?component";
+import { useRouter } from "next/navigation";
+
+export default function NotFound() {
+  const router = useRouter();
+
+  return (
+    <section className="flex h-screen w-full items-center justify-center">
+      <div className="flex max-w-[69rem] flex-col items-center gap-[1.6rem] rounded-[3.2rem] bg-white px-[8.2rem] py-[8.3rem]">
+        <Image src="/icons/warning_icon.svg" alt="waring icon" width={50} height={50} />
+        <h4 className="heading_4 font-bold">요청하신 페이지를 찾을 수 없습니다.</h4>
+        <span className="body_3 text-center">
+          페이지의 주소가 잘못 입력되었거나
+          <br />
+          주소가 변경 혹은 삭제되어 요청하신 페이지를 찾을 수 없습니다.
+        </span>
+        <Button
+          className="px-[16.5rem] py-[1.8rem]"
+          bgColor="bg-navy-900 body_3 mt-[1.6rem]"
+          onClick={() => router.replace("/")}
+        >
+          <RefreshIcon width={20} height={20} />
+          메인으로
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/common/Spinner.tsx
+++ b/src/components/common/Spinner.tsx
@@ -1,0 +1,18 @@
+const Spinner = () => {
+  return (
+    <div className="absolute bottom-[14rem] left-[12.5rem]">
+      {[...Array(8)].map((_, i) => (
+        <div
+          key={i}
+          className={`absolute h-[2.4rem] w-[0.8rem] animate-[changeColor_1s_infinite] rounded-full bg-navy-100 shadow-md`}
+          style={{
+            transform: `rotate(${i * 45}deg) translate(0, -150%)`,
+            animationDelay: `${i * 0.1}s`,
+          }}
+        ></div>
+      ))}
+    </div>
+  );
+};
+
+export default Spinner;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,19 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      keyframes: {
+        changeColor: {
+          "0%": {
+            backgroundColor: "#18254C",
+          },
+          "50%": {
+            backgroundColor: "#C0C8D9",
+          },
+          "100%": {
+            backgroundColor: "#C0C8D9",
+          },
+        },
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic": "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",


### PR DESCRIPTION
## 📌 기능 설명

- not found page
- global error page
- loading page
- spinner

## 📌 구현 내용

각 페이지 구현

## 📌 구현 결과
### not found page
<img width="822" alt="not-found" src="https://github.com/doksuri5/frontend/assets/60169820/e706a76f-d31a-4311-bd6f-89ac3c04f4e4">

### global error page
<img width="848" alt="global-error" src="https://github.com/doksuri5/frontend/assets/60169820/472ac0bf-e689-4a13-b147-3fd2a3100219">

### loading page + spinner
https://github.com/doksuri5/frontend/assets/60169820/aba84ae7-e825-460f-b86a-48a63eae54ce



<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점

각 페이지별로 에러 페이지 구현을 할지 global 로 하나로 쓸지 고민이네요