### PR TITLE
[QJ5-65] 리포트 페이지 UI 구현

### DIFF
--- a/src/app/(news)/news/_components/index.tsx
+++ b/src/app/(news)/news/_components/index.tsx
@@ -4,7 +4,7 @@ import { Card } from "@/components/common";
 import NewsInfinityList from "@/app/(news)/news/_components/NewsInfinityList";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import PopularNews from "@/components/common/PoPularNews";
+import PopularNews from "@/components/common/PopularNews";
 
 export default function News({}) {
   const [currentPage, setCurrentPage] = useState(1);

--- a/src/app/(news)/news/_components/index.tsx
+++ b/src/app/(news)/news/_components/index.tsx
@@ -4,6 +4,7 @@ import { Card } from "@/components/common";
 import NewsInfinityList from "@/app/(news)/news/_components/NewsInfinityList";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import PopularNews from "@/components/common/PoPularNews";
 
 export default function News({}) {
   const [currentPage, setCurrentPage] = useState(1);
@@ -38,37 +39,7 @@ export default function News({}) {
 
   return (
     <div className="flex flex-col gap-[4.8rem] pb-[8rem] pt-[5.6rem]">
-      <div className="flex flex-col gap-[2.4rem]">
-        <h2 className="heading_4 font-bold text-navy-900">오늘 인기있는 뉴스</h2>
-        <div className="flex min-w-[120px] gap-[2rem]">
-          <Card
-            variant="fullMediaCard"
-            title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
-            content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
-            date="2024.06.05"
-            publisher="문화일보"
-            style="w-1/2"
-          />
-          <div className="flex w-1/2 flex-col gap-[2rem]">
-            <Card
-              variant="fullMediaCard"
-              title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
-              content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
-              date="2024.06.05"
-              publisher="문화일보"
-              size="small"
-            />
-            <Card
-              variant="fullMediaCard"
-              title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
-              content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
-              date="2024.06.05"
-              publisher="문화일보"
-              size="small"
-            />
-          </div>
-        </div>
-      </div>
+      <PopularNews />
       <div className="flex w-full flex-col gap-[2.4rem]">
         <h2 className="heading_4 font-bold text-navy-900">관심종목과 관련된 뉴스</h2>
         <div className="flex gap-[2rem]">{Array(3).fill(<Card variant="halfMediaCard" style="w-1/3" />)}</div>

--- a/src/app/(report)/report/[stockReutersCode]/page.tsx
+++ b/src/app/(report)/report/[stockReutersCode]/page.tsx
@@ -1,0 +1,7 @@
+// import Report from "./_components/Report";
+
+import Report from "../_components";
+
+export default function ReportPage({ params }: { params: { stockReutersCode: string } }) {
+  return <Report />;
+}

--- a/src/app/(report)/report/[stockReutersCode]/page.tsx
+++ b/src/app/(report)/report/[stockReutersCode]/page.tsx
@@ -1,5 +1,3 @@
-// import Report from "./_components/Report";
-
 import Report from "../_components";
 
 export default function ReportPage({ params }: { params: { stockReutersCode: string } }) {

--- a/src/app/(report)/report/_components/AIAnalystReport.tsx
+++ b/src/app/(report)/report/_components/AIAnalystReport.tsx
@@ -33,7 +33,7 @@ export default function AIAnalystReport({ data }: TAIAnalystReport) {
           <span>{fluctuationRatio}%</span>
         </div>
       </div>
-      <p>{aiReport}</p>
+      <p className="body_4 font-medium">{aiReport}</p>
       <div className="flex items-center gap-[0.8rem]"></div>
     </div>
   );

--- a/src/app/(report)/report/_components/AIAnalystReport.tsx
+++ b/src/app/(report)/report/_components/AIAnalystReport.tsx
@@ -19,7 +19,7 @@ export default function AIAnalystReport({ data }: TAIAnalystReport) {
   const fluctuationArrow = fluctuationRatio < 0 ? "▼" : "▲";
 
   return (
-    <div className="min-h-[29.5rem] min-w-[75rem] rounded-[1.6rem] bg-white p-[3.2rem]">
+    <section className="min-h-[29.5rem] min-w-[75rem] rounded-[1.6rem] bg-white p-[3.2rem]">
       <h2 className="body_1 pb-[5.5rem] font-bold text-navy-900">아잇나우 AI 애널리스트 리포트</h2>
       <div className="mb-[1.6rem] flex items-center gap-[0.8rem]">
         <Image src={icon} alt="icon" width={30} height={30} />
@@ -35,6 +35,6 @@ export default function AIAnalystReport({ data }: TAIAnalystReport) {
       </div>
       <p className="body_4 font-medium">{aiReport}</p>
       <div className="flex items-center gap-[0.8rem]"></div>
-    </div>
+    </section>
   );
 }

--- a/src/app/(report)/report/_components/AIAnalystReport.tsx
+++ b/src/app/(report)/report/_components/AIAnalystReport.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/utils/cn";
+import Image from "next/image";
+
+type TAIAnalystReport = {
+  data: {
+    icon: string;
+    stockKorName: string;
+    stockCode: string;
+    currentPriceUSD: number;
+    aiReport: string;
+    fluctuationRatio: number;
+    fluctuationPrice: number;
+  };
+};
+
+export default function AIAnalystReport({ data }: TAIAnalystReport) {
+  const { icon, stockKorName, stockCode, currentPriceUSD, aiReport, fluctuationRatio, fluctuationPrice } = data;
+  const fluctuationColor = fluctuationRatio < 0 ? "text-blue-600" : "text-warning-100";
+  const fluctuationArrow = fluctuationRatio < 0 ? "▼" : "▲";
+
+  return (
+    <div className="min-h-[29.5rem] min-w-[75rem] rounded-[1.6rem] bg-white p-[3.2rem]">
+      <h2 className="body_1 pb-[5.5rem] font-bold text-navy-900">아잇나우 AI 애널리스트 리포트</h2>
+      <div className="mb-[1.6rem] flex items-center gap-[0.8rem]">
+        <Image src={icon} alt="icon" width={30} height={30} />
+        <h3 className="body_3 font-bold">{stockKorName}</h3>
+        <h3 className="body_5 font-normal text-grayscale-600">{stockCode}</h3>
+        <div className="body_5 text-right font-medium">
+          <span>${currentPriceUSD}</span>
+        </div>
+        <div className={cn("body_4 flex gap-[0.8rem] font-normal", fluctuationColor)}>
+          <span>{fluctuationArrow + fluctuationPrice}</span>
+          <span>{fluctuationRatio}%</span>
+        </div>
+      </div>
+      <p>{aiReport}</p>
+      <div className="flex items-center gap-[0.8rem]"></div>
+    </div>
+  );
+}

--- a/src/app/(report)/report/_components/ReportHeader.tsx
+++ b/src/app/(report)/report/_components/ReportHeader.tsx
@@ -5,23 +5,23 @@ type TStockHeader = {
   data: { icon: string; stockKorName: string; stockEngName: string };
 };
 
-export default function RePortHeader({ data }: TStockHeader) {
+export default function ReportHeader({ data }: TStockHeader) {
   const { icon, stockKorName, stockEngName } = data;
   return (
-    <div className="flex_row justify-between">
+    <section className="flex_row justify-between">
       <div className="flex items-center gap-[1.4rem]">
         <div className="relative h-[6.4rem] w-[6.4rem]">
           <Image src={icon} alt="stock-icon" style={{ width: "100%" }} />
         </div>
         <div className="flex_row gap-[0.8rem] text-navy-900">
-          <h3 className="heading_4 font-bold">{stockKorName}</h3>
-          <h3 className="body_2 font-normal">∙</h3>
-          <h3 className="body_2 font-normal">{stockEngName}</h3>
+          <h1 className="heading_4 font-bold">{stockKorName}</h1>
+          <h1 className="body_2 font-normal">∙</h1>
+          <h1 className="body_2 font-normal">{stockEngName}</h1>
         </div>
       </div>
       <Button variant="textButton" size="md" className="w-[18rem] text-white">
         관심종목 추가
       </Button>
-    </div>
+    </section>
   );
 }

--- a/src/app/(report)/report/_components/ReportHeader.tsx
+++ b/src/app/(report)/report/_components/ReportHeader.tsx
@@ -1,12 +1,17 @@
+"use client";
+
 import { Button } from "@/components/common";
 import Image from "next/image";
+import { useState } from "react";
 
 type TStockHeader = {
-  data: { icon: string; stockKorName: string; stockEngName: string };
+  data: { icon: string; stockKorName: string; stockEngName: string; isMyStock: boolean };
 };
 
 export default function ReportHeader({ data }: TStockHeader) {
-  const { icon, stockKorName, stockEngName } = data;
+  const { icon, stockKorName, stockEngName, isMyStock } = data;
+  const [isMyStockState, setIsMyStockState] = useState(isMyStock);
+
   return (
     <section className="flex_row justify-between">
       <div className="flex items-center gap-[1.4rem]">
@@ -19,9 +24,26 @@ export default function ReportHeader({ data }: TStockHeader) {
           <h1 className="body_2 font-normal">{stockEngName}</h1>
         </div>
       </div>
-      <Button variant="textButton" size="md" className="w-[18rem] text-white">
-        관심종목 추가
-      </Button>
+      {isMyStockState ? (
+        <Button
+          variant="textButton"
+          size="md"
+          className="w-[18rem] bg-transparent"
+          bgColor="bg-white"
+          onClick={() => setIsMyStockState(!isMyStockState)}
+        >
+          관심종목 해제
+        </Button>
+      ) : (
+        <Button
+          variant="textButton"
+          size="md"
+          className="w-[18rem] text-white"
+          onClick={() => setIsMyStockState(!isMyStockState)}
+        >
+          관심종목 추가
+        </Button>
+      )}
     </section>
   );
 }

--- a/src/app/(report)/report/_components/ReportHeader.tsx
+++ b/src/app/(report)/report/_components/ReportHeader.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/common";
+import Image from "next/image";
+
+type TStockHeader = {
+  data: { icon: string; stockKorName: string; stockEngName: string };
+};
+
+export default function RePortHeader({ data }: TStockHeader) {
+  const { icon, stockKorName, stockEngName } = data;
+  return (
+    <div className="flex_row justify-between">
+      <div className="flex items-center gap-[1.4rem]">
+        <div className="relative h-[6.4rem] w-[6.4rem]">
+          <Image src={icon} alt="stock-icon" style={{ width: "100%" }} />
+        </div>
+        <div className="flex_row gap-[0.8rem] text-navy-900">
+          <h3 className="heading_4 font-bold">{stockKorName}</h3>
+          <h3 className="body_2 font-normal">∙</h3>
+          <h3 className="body_2 font-normal">{stockEngName}</h3>
+        </div>
+      </div>
+      <Button variant="textButton" size="md" className="w-[18rem] text-white">
+        관심종목 추가
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(report)/report/_components/StockAIReport.tsx
+++ b/src/app/(report)/report/_components/StockAIReport.tsx
@@ -1,0 +1,70 @@
+import { SimpleRadarChart } from "@/components/common";
+import { cn } from "@/utils/cn";
+import Image from "next/image";
+import { useCallback } from "react";
+
+type StockAIReport = {
+  data: {
+    fluctuationRatio: number;
+    score: number;
+  };
+};
+
+export default function StockAIReport({ data }: StockAIReport) {
+  const { fluctuationRatio, score } = data;
+
+  const fluctuationColor = fluctuationRatio < 0 ? "text-blue-600" : "text-warning-100";
+  const fluctuationArrow = fluctuationRatio < 0 ? "▼" : "▲";
+
+  const changeArrow = useCallback((ratio: number) => {
+    return ratio < 0 ? "▼" : "▲";
+  }, []);
+
+  return (
+    <section className="min-h-[29.5rem] min-w-[43rem]">
+      <div className="h-[29.5rem] flex-1 rounded-[1.6rem] bg-white p-[3.2rem]">
+        <div className="flex justify-between gap-[0.8rem]">
+          <h2 className="body_1 font-bold text-navy-900">종목 AI 리포트</h2>
+          <h2 className="heading_3 font-medium text-grayscale-700">{score}점</h2>
+        </div>
+        <div className="flex h-full w-full items-center gap-[0.8rem]">
+          <div className="h-full w-[80%] min-w-[13rem] p-[1.6rem]">
+            <SimpleRadarChart />
+          </div>
+          <ul className="body_6 flex h-auto min-w-[14rem] flex-col gap-[0.4rem] rounded-[2.4rem] bg-[#F9F9F9] p-[1.6rem]">
+            <li className="flex justify-between">
+              주가
+              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
+                <span>{fluctuationArrow + fluctuationRatio}%</span>
+              </div>
+            </li>
+            <li className="flex justify-between">
+              투자지수
+              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
+                <span>{fluctuationArrow + fluctuationRatio}%</span>
+              </div>
+            </li>
+            <li className="flex justify-between">
+              수익성
+              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
+                <span>{fluctuationArrow + fluctuationRatio}%</span>
+              </div>
+            </li>
+            <li className="flex justify-between">
+              성장성
+              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
+                <span>{fluctuationArrow + fluctuationRatio}%</span>
+              </div>
+            </li>
+            <li className="flex justify-between">
+              관심도
+              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
+                <span>{fluctuationArrow + fluctuationRatio}%</span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(report)/report/_components/StockAIReport.tsx
+++ b/src/app/(report)/report/_components/StockAIReport.tsx
@@ -1,7 +1,6 @@
 import { SimpleRadarChart } from "@/components/common";
 import { cn } from "@/utils/cn";
-import Image from "next/image";
-import { useCallback } from "react";
+import { getCompareToPreviousClosePriceArrow, getFluctuationsRatioColor } from "@/utils/stockPriceUtils";
 
 type StockAIReport = {
   data: {
@@ -13,12 +12,8 @@ type StockAIReport = {
 export default function StockAIReport({ data }: StockAIReport) {
   const { fluctuationRatio, score } = data;
 
-  const fluctuationColor = fluctuationRatio < 0 ? "text-blue-600" : "text-warning-100";
-  const fluctuationArrow = fluctuationRatio < 0 ? "▼" : "▲";
-
-  const changeArrow = useCallback((ratio: number) => {
-    return ratio < 0 ? "▼" : "▲";
-  }, []);
+  const fluctuationColor = getFluctuationsRatioColor(fluctuationRatio);
+  const fluctuationArrow = getCompareToPreviousClosePriceArrow(fluctuationRatio);
 
   return (
     <section className="min-h-[29.5rem] min-w-[43rem]">

--- a/src/app/(report)/report/_components/StockChart.tsx
+++ b/src/app/(report)/report/_components/StockChart.tsx
@@ -1,37 +1,28 @@
-// "use client";
-
-import { useEffect } from "react";
 import { Area, AreaChart, Tooltip, XAxis, YAxis } from "recharts";
 
-const DUMMY_CHART_DATA = [
-  { period: "2024/04/1week", price: 41310 },
-  { period: "2024/04/2week", price: 32030 },
-  { period: "2024/04/3week", price: 20400 },
-  { period: "2024/04/4week", price: 27820 },
-  { period: "2024/05/1week", price: 18910 },
-  { period: "2024/05/2week", price: 23900 },
-  { period: "2024/05/3week", price: 34920 },
-  { period: "2024/05/4week", price: 20060 },
-  { period: "2024/06/1week", price: 27890 },
-  { period: "2024/06/2week", price: 18980 },
-  { period: "2024/06/3week", price: 23910 },
-  { period: "2024/06/4week", price: 34920 },
-];
+type TChartData = {
+  chartData: {
+    period: string;
+    price: number;
+  }[];
+};
 
-export default function StockChart({}) {
+export default function StockChart({ chartData }: TChartData) {
   const error = console.error;
   console.error = (...args: any) => {
     if (/defaultProps/.test(args[0])) return;
     error(...args);
   };
+
   // 각 월의 중앙에 위치할 레이블의 인덱스 계산
   const monthTicks = [
-    DUMMY_CHART_DATA[1].period, // 2024/04
-    DUMMY_CHART_DATA[5].period, // 2024/05
-    DUMMY_CHART_DATA[9].period, // 2024/06
+    chartData[1].period, // 2024/04
+    chartData[5].period, // 2024/05
+    chartData[9].period, // 2024/06
   ];
+
   return (
-    <AreaChart data={DUMMY_CHART_DATA} width={610} height={145} margin={{ top: 10 }}>
+    <AreaChart data={chartData} width={640} height={145} margin={{ top: 10 }}>
       <defs>
         <linearGradient id="customGradient" x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="rgba(71, 180, 225, 0.7)" />

--- a/src/app/(report)/report/_components/StockChart.tsx
+++ b/src/app/(report)/report/_components/StockChart.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Area, AreaChart, Tooltip, XAxis, YAxis } from "recharts";
 
 type TChartData = {
@@ -8,11 +11,20 @@ type TChartData = {
 };
 
 export default function StockChart({ chartData }: TChartData) {
-  const error = console.error;
-  console.error = (...args: any) => {
-    if (/defaultProps/.test(args[0])) return;
-    error(...args);
-  };
+  // Recharts컴포넌트 렌더링 시 클라이언트에서만 렌더링되도록 하기 위함
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    const error = console.error;
+
+    console.error = (...args: any) => {
+      if (/defaultProps/.test(args[0])) return;
+
+      error(...args);
+    };
+
+    setIsClient(true);
+  }, []);
 
   // 각 월의 중앙에 위치할 레이블의 인덱스 계산
   const monthTicks = [
@@ -20,6 +32,8 @@ export default function StockChart({ chartData }: TChartData) {
     chartData[5].period, // 2024/05
     chartData[9].period, // 2024/06
   ];
+
+  if (!isClient) return null;
 
   return (
     <AreaChart data={chartData} width={640} height={145} margin={{ top: 10 }}>

--- a/src/app/(report)/report/_components/StockChart.tsx
+++ b/src/app/(report)/report/_components/StockChart.tsx
@@ -1,0 +1,62 @@
+// "use client";
+
+import { useEffect } from "react";
+import { Area, AreaChart, Tooltip, XAxis, YAxis } from "recharts";
+
+const DUMMY_CHART_DATA = [
+  { period: "2024/04/1week", price: 41310 },
+  { period: "2024/04/2week", price: 32030 },
+  { period: "2024/04/3week", price: 20400 },
+  { period: "2024/04/4week", price: 27820 },
+  { period: "2024/05/1week", price: 18910 },
+  { period: "2024/05/2week", price: 23900 },
+  { period: "2024/05/3week", price: 34920 },
+  { period: "2024/05/4week", price: 20060 },
+  { period: "2024/06/1week", price: 27890 },
+  { period: "2024/06/2week", price: 18980 },
+  { period: "2024/06/3week", price: 23910 },
+  { period: "2024/06/4week", price: 34920 },
+];
+
+export default function StockChart({}) {
+  const error = console.error;
+  console.error = (...args: any) => {
+    if (/defaultProps/.test(args[0])) return;
+    error(...args);
+  };
+  // 각 월의 중앙에 위치할 레이블의 인덱스 계산
+  const monthTicks = [
+    DUMMY_CHART_DATA[1].period, // 2024/04
+    DUMMY_CHART_DATA[5].period, // 2024/05
+    DUMMY_CHART_DATA[9].period, // 2024/06
+  ];
+  return (
+    <AreaChart data={DUMMY_CHART_DATA} width={610} height={145} margin={{ top: 10 }}>
+      <defs>
+        <linearGradient id="customGradient" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="rgba(71, 180, 225, 0.7)" />
+          <stop offset="100%" stopColor="rgba(71, 180, 225, 0.07)" />
+        </linearGradient>
+      </defs>
+      <XAxis
+        dataKey="period"
+        ticks={monthTicks}
+        tickFormatter={(tick: string) => {
+          const [year, month] = tick.split("/");
+          return `${year}/${month}`;
+        }}
+        tick={{ fontSize: 12, fontWeight: 400, fill: "#9F9F9F", dx: 20 }} // 레이블 스타일
+        tickLine={false} // 레이블 선 스타일
+        axisLine={false} // 축 스타일
+      />
+      <YAxis
+        orientation="right"
+        axisLine={false} // 축 스타일
+        tickLine={false}
+        tick={{ fontSize: 12, fontWeight: 400, fill: "#9F9F9F" }} // 레이블 스타일
+      />
+      <Tooltip />
+      <Area type="monotone" dataKey="price" stroke="#47B4E1" fillOpacity={1} fill="url(#customGradient)" />
+    </AreaChart>
+  );
+}

--- a/src/app/(report)/report/_components/StockChartSection.tsx
+++ b/src/app/(report)/report/_components/StockChartSection.tsx
@@ -18,7 +18,7 @@ export default function StockChartSection({ chartData }: TChartData) {
   const chartButton = ["1일", "3개월", "1년", "3년", "10년"];
 
   return (
-    <div className="flex min-h-[25.6rem] min-w-[69.2rem] flex-col gap-[0.8rem] rounded-[1.6rem] bg-white p-[3.2rem]">
+    <section className="flex min-h-[25.6rem] min-w-[69.2rem] flex-col gap-[0.8rem] rounded-[1.6rem] bg-white p-[3.2rem]">
       <div className="flex flex-row justify-between gap-[0.8rem]">
         <h2 className="body_1 font-bold text-navy-900">주가차트</h2>
         <div className="flex">
@@ -38,6 +38,6 @@ export default function StockChartSection({ chartData }: TChartData) {
         </div>
       </div>
       <StockChart chartData={chartData} />
-    </div>
+    </section>
   );
 }

--- a/src/app/(report)/report/_components/StockChartSection.tsx
+++ b/src/app/(report)/report/_components/StockChartSection.tsx
@@ -14,7 +14,7 @@ type TChartData = {
 };
 
 export default function StockChartSection({ chartData }: TChartData) {
-  const [period, setPeriod] = useState("1일");
+  const [period, setPeriod] = useState("3개월");
   const chartButton = ["1일", "3개월", "1년", "3년", "10년"];
 
   return (

--- a/src/app/(report)/report/_components/StockChartSection.tsx
+++ b/src/app/(report)/report/_components/StockChartSection.tsx
@@ -8,8 +8,8 @@ import clsx from "clsx";
 
 type TChartData = {
   chartData: {
-    name: string;
-    uv: number;
+    period: string;
+    price: number;
   }[];
 };
 
@@ -37,7 +37,7 @@ export default function StockChartSection({ chartData }: TChartData) {
           ))}
         </div>
       </div>
-      <StockChart />
+      <StockChart chartData={chartData} />
     </div>
   );
 }

--- a/src/app/(report)/report/_components/StockChartSection.tsx
+++ b/src/app/(report)/report/_components/StockChartSection.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Button } from "@/components/common";
+import { cn } from "@/utils/cn";
+import { useState } from "react";
+import StockChart from "./StockChart";
+import clsx from "clsx";
+
+type TChartData = {
+  chartData: {
+    name: string;
+    uv: number;
+  }[];
+};
+
+export default function StockChartSection({ chartData }: TChartData) {
+  const [period, setPeriod] = useState("1일");
+  const chartButton = ["1일", "3개월", "1년", "3년", "10년"];
+
+  return (
+    <div className="flex min-h-[25.6rem] min-w-[69.2rem] flex-col gap-[0.8rem] rounded-[1.6rem] bg-white p-[3.2rem]">
+      <div className="flex flex-row justify-between gap-[0.8rem]">
+        <h2 className="body_1 font-bold text-navy-900">주가차트</h2>
+        <div className="flex">
+          {chartButton.map((button, idx) => (
+            <Button
+              key={idx}
+              size="sm"
+              className={cn(
+                "min-h-[3.2rem] min-w-[6.4rem]",
+                clsx(period === button ? "bg-[#E6E9EF] text-navy-900" : "bg-[#FFFFF] text-grayscale-400"),
+              )}
+              onClick={() => setPeriod(button)}
+            >
+              {button}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <StockChart />
+    </div>
+  );
+}

--- a/src/app/(report)/report/_components/StockDetail.tsx
+++ b/src/app/(report)/report/_components/StockDetail.tsx
@@ -36,7 +36,7 @@ export default function StockDetail({ stockDetail }: TStockDetail) {
   const viewStockName = currency ? stockEngName : stockKorName;
 
   return (
-    <div className="min-h-[25.6rem] min-w-[48.8rem] rounded-[1.6rem] bg-white p-[3.2rem]">
+    <section className="min-h-[25.6rem] min-w-[48.8rem] rounded-[1.6rem] bg-white p-[3.2rem]">
       <div className="flex flex-col gap-[3.2rem]">
         <div>
           <div className="flex_row justify-between">
@@ -59,6 +59,6 @@ export default function StockDetail({ stockDetail }: TStockDetail) {
         </div>
         <p>{description}</p>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/app/(report)/report/_components/StockDetail.tsx
+++ b/src/app/(report)/report/_components/StockDetail.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Toggle } from "@/components/common";
 import { cn } from "@/utils/cn";
+import { getCompareToPreviousClosePriceArrow, getFluctuationsRatioColor } from "@/utils/stockPriceUtils";
 
 type TStockDetail = {
   stockDetail: {
@@ -28,8 +29,8 @@ export default function StockDetail({ stockDetail }: TStockDetail) {
     description,
   } = stockDetail;
 
-  const fluctuationColor = fluctuationRatio < 0 ? "text-blue-600" : "text-warning-100";
-  const fluctuationArrow = fluctuationRatio < 0 ? "▼" : "▲";
+  const fluctuationColor = getFluctuationsRatioColor(fluctuationRatio);
+  const fluctuationArrow = getCompareToPreviousClosePriceArrow(fluctuationRatio);
   const fluctuationSign = fluctuationRatio < 0 ? "-" : "+";
   const viewCurrency = currency ? `$${currentPriceUSD}` : `₩${currentPriceKRW}`;
   const viewStockName = currency ? stockEngName : stockKorName;

--- a/src/app/(report)/report/_components/StockDetail.tsx
+++ b/src/app/(report)/report/_components/StockDetail.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { Toggle } from "@/components/common";
+import { cn } from "@/utils/cn";
+
+type TStockDetail = {
+  stockDetail: {
+    currentPriceUSD: number;
+    currentPriceKRW: string;
+    stockEngName: string;
+    stockKorName: string;
+    fluctuationPrice: number;
+    fluctuationRatio: number;
+    description: string;
+  };
+};
+
+export default function StockDetail({ stockDetail }: TStockDetail) {
+  const [currency, setCurrency] = useState(false);
+  const {
+    currentPriceUSD,
+    currentPriceKRW,
+    stockEngName,
+    stockKorName,
+    fluctuationPrice,
+    fluctuationRatio,
+    description,
+  } = stockDetail;
+
+  const fluctuationColor = fluctuationRatio < 0 ? "text-blue-600" : "text-warning-100";
+  const fluctuationArrow = fluctuationRatio < 0 ? "▼" : "▲";
+  const fluctuationSign = fluctuationRatio < 0 ? "-" : "+";
+  const viewCurrency = currency ? `$${currentPriceUSD}` : `₩${currentPriceKRW}`;
+  const viewStockName = currency ? stockEngName : stockKorName;
+
+  return (
+    <div className="min-h-[25.6rem] min-w-[48.8rem] rounded-[1.6rem] bg-white p-[3.2rem]">
+      <div className="flex flex-col gap-[3.2rem]">
+        <div>
+          <div className="flex_row justify-between">
+            <div>
+              <div className="flex_row gap-[0.4rem]">
+                <span className="body_1 font-bold">{viewCurrency}</span>
+                <span className="body_1 font-bold">∙</span>
+                <span className="body_2 font-normal">{viewStockName}</span>
+              </div>
+              <div className={cn(`flex_row body_2 gap-[0.8rem] font-normal ${fluctuationColor}`)}>
+                <span>{fluctuationArrow + fluctuationPrice}</span>
+                <span>
+                  {fluctuationSign}
+                  {fluctuationRatio}%
+                </span>
+              </div>
+            </div>
+            <Toggle checked={currency} setChecked={setCurrency} />
+          </div>
+        </div>
+        <p>{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(report)/report/_components/index.tsx
+++ b/src/app/(report)/report/_components/index.tsx
@@ -50,6 +50,7 @@ export default function Report() {
     aiReport,
     score,
   } = DUMMY_STCOK;
+
   return (
     <div className="flex flex-col gap-[2.4rem] pb-[12rem] pt-[4.7rem]">
       <ReportHeader

--- a/src/app/(report)/report/_components/index.tsx
+++ b/src/app/(report)/report/_components/index.tsx
@@ -19,6 +19,7 @@ const DUMMY_STCOK = {
   aiReport: `급격한 금리 인상에도 견조한 자동차 수요를 반영하여 테슬라의 목표주가를 340달러로 26% 상향 조정하고 Top Pick으로 유지한다. 단기 상승에 따른 숨 고르기가 예상되지만, 중기적으로 동사의 경쟁우위는 더 강해지고 있다. 기존 OEM의 전기차 전환이 더디고 중국 신생 업체들의 현금 흐름이 약화되고있는 가운데, 
 테슬라의 멕시코 공장이 가동되면 전기차 제조 경쟁력 격차는 더 벌어질 것으로 예상된다.`,
   score: 70,
+  isMyStock: false,
 };
 
 const DUMMY_CHART = [
@@ -49,6 +50,7 @@ export default function Report() {
     description,
     aiReport,
     score,
+    isMyStock,
   } = DUMMY_STCOK;
 
   return (
@@ -58,6 +60,7 @@ export default function Report() {
           icon,
           stockKorName,
           stockEngName,
+          isMyStock,
         }}
       />
       <div className="flex gap-[2.1rem]">

--- a/src/app/(report)/report/_components/index.tsx
+++ b/src/app/(report)/report/_components/index.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import AppleIcon from "@/public/icons/Apple_icon.svg";
+import RePortHeader from "./ReportHeader";
+import StockDetail from "./StockDetail";
+import StockChartSection from "./StockChartSection";
+import AIAnalystReport from "./AIAnalystReport";
+import StockAIReport from "./StockAIReport";
+import PopularNews from "@/components/common/PoPularNews";
+
+const DUMMY_STCOK = {
+  icon: AppleIcon,
+  stockCode: "ERS462",
+  stockKorName: "애플",
+  stockEngName: "APPL",
+  currentPriceUSD: 15.28,
+  currentPriceKRW: "21,105",
+  fluctuationPrice: 1.75,
+  fluctuationRatio: 0.82,
+  description: `애플은 스마트폰, 개인용 컴퓨터, 태블릿, 웨어러블 및 액세서리를 설계, 제조 및 판매하고 다양한 관련 서비스를 판매한다. 제품 카테고리는 iPhone, MAc, iPad, Wearables, Home 및 Accessories로 나뉜다.`,
+  aiReport: `급격한 금리 인상에도 견조한 자동차 수요를 반영하여 테슬라의 목표주가를 340달러로 26% 상향 조정하고 Top Pick으로 유지한다. 단기 상승에 따른 숨 고르기가 예상되지만, 중기적으로 동사의 경쟁우위는 더 강해지고 있다. 기존 OEM의 전기차 전환이 더디고 중국 신생 업체들의 현금 흐름이 약화되고있는 가운데, 
+테슬라의 멕시코 공장이 가동되면 전기차 제조 경쟁력 격차는 더 벌어질 것으로 예상된다.`,
+  score: 70,
+};
+
+const DUMMY_CHART = [
+  { name: "2024/04/1week", uv: 4000 },
+  { name: "2024/04/2week", uv: 3000 },
+  { name: "2024/04/3week", uv: 2000 },
+  { name: "2024/04/4week", uv: 2780 },
+  { name: "2024/05/1week", uv: 1890 },
+  { name: "2024/05/2week", uv: 2390 },
+  { name: "2024/05/3week", uv: 3490 },
+  { name: "2024/05/4week", uv: 2000 },
+  { name: "2024/06/1week", uv: 2780 },
+  { name: "2024/06/2week", uv: 1890 },
+  { name: "2024/06/3week", uv: 2390 },
+  { name: "2024/06/4week", uv: 3490 },
+];
+
+export default function Report() {
+  const {
+    icon,
+    stockCode,
+    stockKorName,
+    stockEngName,
+    currentPriceUSD,
+    currentPriceKRW,
+    fluctuationPrice,
+    fluctuationRatio,
+    description,
+    aiReport,
+    score,
+  } = DUMMY_STCOK;
+  // px-[12rem]
+  return (
+    <div className="flex flex-col gap-[2.4rem] pb-[12rem] pt-[4.7rem]">
+      <RePortHeader
+        data={{
+          icon,
+          stockKorName,
+          stockEngName,
+        }}
+      />
+      <div className="flex gap-[2.1rem]">
+        <StockDetail
+          stockDetail={{
+            currentPriceUSD,
+            currentPriceKRW,
+            stockEngName,
+            stockKorName,
+            fluctuationPrice,
+            fluctuationRatio,
+            description,
+          }}
+        />
+        <StockChartSection chartData={DUMMY_CHART} />
+      </div>
+      <div className="flex flex-row gap-[2.1rem]">
+        <StockAIReport data={{ fluctuationRatio, score }} />
+        <AIAnalystReport
+          data={{
+            icon,
+            stockKorName,
+            stockCode,
+            currentPriceUSD,
+            aiReport,
+            fluctuationRatio,
+            fluctuationPrice,
+          }}
+        />
+      </div>
+      <PopularNews />
+    </div>
+  );
+}

--- a/src/app/(report)/report/_components/index.tsx
+++ b/src/app/(report)/report/_components/index.tsx
@@ -1,12 +1,10 @@
-"use client";
-
 import AppleIcon from "@/public/icons/Apple_icon.svg";
-import RePortHeader from "./ReportHeader";
+import ReportHeader from "./ReportHeader";
 import StockDetail from "./StockDetail";
 import StockChartSection from "./StockChartSection";
 import AIAnalystReport from "./AIAnalystReport";
 import StockAIReport from "./StockAIReport";
-import PopularNews from "@/components/common/PoPularNews";
+import PopularNews from "@/components/common/PopularNews";
 
 const DUMMY_STCOK = {
   icon: AppleIcon,
@@ -24,18 +22,18 @@ const DUMMY_STCOK = {
 };
 
 const DUMMY_CHART = [
-  { name: "2024/04/1week", uv: 4000 },
-  { name: "2024/04/2week", uv: 3000 },
-  { name: "2024/04/3week", uv: 2000 },
-  { name: "2024/04/4week", uv: 2780 },
-  { name: "2024/05/1week", uv: 1890 },
-  { name: "2024/05/2week", uv: 2390 },
-  { name: "2024/05/3week", uv: 3490 },
-  { name: "2024/05/4week", uv: 2000 },
-  { name: "2024/06/1week", uv: 2780 },
-  { name: "2024/06/2week", uv: 1890 },
-  { name: "2024/06/3week", uv: 2390 },
-  { name: "2024/06/4week", uv: 3490 },
+  { period: "2024/04/1week", price: 4000 },
+  { period: "2024/04/2week", price: 3000 },
+  { period: "2024/04/3week", price: 2000 },
+  { period: "2024/04/4week", price: 2780 },
+  { period: "2024/05/1week", price: 1890 },
+  { period: "2024/05/2week", price: 2390 },
+  { period: "2024/05/3week", price: 3490 },
+  { period: "2024/05/4week", price: 2000 },
+  { period: "2024/06/1week", price: 2780 },
+  { period: "2024/06/2week", price: 1890 },
+  { period: "2024/06/3week", price: 2390 },
+  { period: "2024/06/4week", price: 3490 },
 ];
 
 export default function Report() {
@@ -52,10 +50,9 @@ export default function Report() {
     aiReport,
     score,
   } = DUMMY_STCOK;
-  // px-[12rem]
   return (
     <div className="flex flex-col gap-[2.4rem] pb-[12rem] pt-[4.7rem]">
-      <RePortHeader
+      <ReportHeader
         data={{
           icon,
           stockKorName,

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -67,7 +67,7 @@ export default function Card({
       return (
         <div className={cn(`flex min-h-[36rem] min-w-[38.8rem] flex-col overflow-hidden rounded-[1.6rem] ${style}`)}>
           <div className="relative min-h-[23.6rem] w-[100%]">
-            <Image src={image || Rectangle} alt="news-image" style={{ width: "100%" }} />
+            <Image src={image || Rectangle} alt="news-image" />
           </div>
           <div className="flex w-full flex-col gap-[.8rem] rounded-b-[1.6rem] bg-grayscale-0 px-[2.4rem] py-[1.6rem] font-medium">
             <div className="body_3 line-clamp-2 h-[5.6rem] cursor-pointer text-ellipsis text-grayscale-900">
@@ -93,10 +93,10 @@ export default function Card({
         >
           <div className="relative h-[100%] w-[100%]">
             <Image
-              layout="fill"
+              fill
               src={image || (size === "large" ? LargeRect : SmallRect)}
               alt="news-image"
-              className="object-cover"
+              sizes={`${size === "large" ? "minHeight: 26.25rem" : "minHeight: 12.5rem"} minWidth: 36.875rem`}
             />
           </div>
           <div className="absolute bottom-0 w-full bg-gradient-to-t from-black to-transparent p-[2.4rem]">

--- a/src/components/common/PoPularNews.tsx
+++ b/src/components/common/PoPularNews.tsx
@@ -6,6 +6,7 @@ const PopularNews = () => {
       <h2 className="heading_4 font-bold text-navy-900">오늘 인기있는 뉴스</h2>
       <div className="flex min-w-[120px] gap-[2rem]">
         <Card
+          image="/icons/news.jpg"
           variant="fullMediaCard"
           title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
           content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
@@ -15,6 +16,7 @@ const PopularNews = () => {
         />
         <div className="flex w-1/2 flex-col gap-[2rem]">
           <Card
+            image="/icons/news.jpg"
             variant="fullMediaCard"
             title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
             content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
@@ -23,6 +25,7 @@ const PopularNews = () => {
             size="small"
           />
           <Card
+            image="/icons/news.jpg"
             variant="fullMediaCard"
             title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
             content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."

--- a/src/components/common/PoPularNews.tsx
+++ b/src/components/common/PoPularNews.tsx
@@ -1,0 +1,39 @@
+import Card from "./Card";
+
+const PopularNews = () => {
+  return (
+    <div className="flex flex-col gap-[2.4rem]">
+      <h2 className="heading_4 font-bold text-navy-900">오늘 인기있는 뉴스</h2>
+      <div className="flex min-w-[120px] gap-[2rem]">
+        <Card
+          variant="fullMediaCard"
+          title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
+          content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
+          date="2024.06.05"
+          publisher="문화일보"
+          style="w-1/2"
+        />
+        <div className="flex w-1/2 flex-col gap-[2rem]">
+          <Card
+            variant="fullMediaCard"
+            title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
+            content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
+            date="2024.06.05"
+            publisher="문화일보"
+            size="small"
+          />
+          <Card
+            variant="fullMediaCard"
+            title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
+            content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
+            date="2024.06.05"
+            publisher="문화일보"
+            size="small"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PopularNews;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -17,6 +17,7 @@ import StockItemSkeleton from "./List/skeleton/StockItemSkeleton";
 import ChatBot from "./ChatBot";
 import Alert from "./Alert";
 import PopularNews from "./PoPularNews";
+import SimpleRadarChart from "./SimpleRadarChart";
 
 export {
   Button,
@@ -37,5 +38,6 @@ export {
   FindNewsSkeleton,
   StockItemSkeleton,
   Alert,
+  SimpleRadarChart,
   PopularNews,
 };

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -16,6 +16,7 @@ import FindNewsSkeleton from "./List/skeleton/FindNewsSkeleton";
 import StockItemSkeleton from "./List/skeleton/StockItemSkeleton";
 import ChatBot from "./ChatBot";
 import Alert from "./Alert";
+import PopularNews from "./PoPularNews";
 
 export {
   Button,
@@ -36,4 +37,5 @@ export {
   FindNewsSkeleton,
   StockItemSkeleton,
   Alert,
+  PopularNews,
 };

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -16,7 +16,7 @@ import FindNewsSkeleton from "./List/skeleton/FindNewsSkeleton";
 import StockItemSkeleton from "./List/skeleton/StockItemSkeleton";
 import ChatBot from "./ChatBot";
 import Alert from "./Alert";
-import PopularNews from "./PoPularNews";
+import PopularNews from "./PopularNews";
 import SimpleRadarChart from "./SimpleRadarChart";
 
 export {

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -12,3 +12,4 @@ export const REGISTER_PATH = "/register";
 export const REGISTER_COMPLETE_PATH = "/register-complete";
 export const VERIFY_USER_PATH = "/verify-user";
 export const WITHDRAW_PATH = "/withdraw";
+export const REPORT_PATH = "/report";


### PR DESCRIPTION
## 📌 기능 설명

<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업
- [x] 헤더 컴포넌트 구현
-->

- [x] 리포트 페이지 UI 구현

## 📌 구현 내용

<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다.
-->

- 주가 차트에 사용된 데이터가 어떻게 구성되어있을지 아직 알 수 없어서 3개월 기준으로만 대략 작성해서 구현했습니다.
   - 그래서 주가 차트의 버튼도 UI만 구현되어 있습니다.


## 📌 구현 결과

<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

https://github.com/doksuri5/frontend/assets/55550034/deacf4f0-2729-4753-a715-7c3b485c740b



## 📌 논의하고 싶은 점

<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요?
-->

- 주가 차트 섹션의 y축과 버튼 위치(1일, 3개월...)는 피그마와 다르게 구현한 부분이라서 배치가 괜찮은지 함께 봐주세요!