### PR TITLE
[QJ5-73] 뉴스 관련 카드, 뉴스에 더미데이터 추가 및 Link태그 추가

### DIFF
--- a/src/app/(home)/news.tsx
+++ b/src/app/(home)/news.tsx
@@ -5,6 +5,8 @@ import NewsItem, { TINewsItemProps } from "@/components/common/List/NewsItem";
 import useDraggable from "@/hooks/use-draggable";
 import { useRef } from "react";
 import NewsImage from "@/public/icons/news.jpg";
+import Link from "next/link";
+import { NEWS_PATH } from "@/routes/path";
 
 const NEWS = [
   {
@@ -63,32 +65,38 @@ const News = () => {
         </ul>
         <p className="body_1 pb-[1.6rem] pt-[4.8rem]">주요 뉴스</p>
         <ul className="flex flex-col gap-[1.6rem] divide-y rounded-[1.6rem] border p-[4.8rem]">
-          <div key={DUMMY_NEWS_ITEMS[0].title} className="shadow-smhg pb-[3.2rem] pt-[1.6rem]">
-            <NewsItem
-              variant="lineClamp-4"
-              image={DUMMY_NEWS_ITEMS[0].image}
-              title={DUMMY_NEWS_ITEMS[0].title}
-              description={DUMMY_NEWS_ITEMS[0].description}
-              publishedTime={DUMMY_NEWS_ITEMS[0].publishedTime}
-              newspaperCompany={DUMMY_NEWS_ITEMS[0].newspaperCompany}
-              key={DUMMY_NEWS_ITEMS[0].title}
-            />
-          </div>
+          <Link href={`${NEWS_PATH}/${DUMMY_NEWS_ITEMS[0].id}`}>
+            <div key={DUMMY_NEWS_ITEMS[0].title} className="shadow-smhg pb-[3.2rem] pt-[1.6rem]">
+              <NewsItem
+                id={DUMMY_NEWS_ITEMS[0].id}
+                variant="lineClamp-4"
+                image={DUMMY_NEWS_ITEMS[0].image}
+                title={DUMMY_NEWS_ITEMS[0].title}
+                description={DUMMY_NEWS_ITEMS[0].description}
+                publishedTime={DUMMY_NEWS_ITEMS[0].publishedTime}
+                newspaperCompany={DUMMY_NEWS_ITEMS[0].newspaperCompany}
+                key={DUMMY_NEWS_ITEMS[0].title}
+              />
+            </div>
+          </Link>
         </ul>
         <p className="body_1 pb-[1.6rem] pt-[4.8rem]">최신 뉴스</p>
         <ul className="flex flex-col gap-[1.6rem] divide-y rounded-[1.6rem] border p-[4.8rem]">
           {DUMMY_NEWS_ITEMS.map((newsItem) => (
-            <div key={newsItem.title} className="shadow-smhg pb-[3.2rem] pt-[1.6rem]">
-              <NewsItem
-                image={newsItem.image}
-                title={newsItem.title}
-                description={newsItem.description}
-                publishedTime={newsItem.publishedTime}
-                newspaperCompany={newsItem.newspaperCompany}
-                variant={newsItem.variant}
-                key={newsItem.title}
-              />
-            </div>
+            <Link key={newsItem.title} href={`${NEWS_PATH}/${newsItem.id}`}>
+              <div className="shadow-smhg pb-[3.2rem] pt-[1.6rem]">
+                <NewsItem
+                  id={DUMMY_NEWS_ITEMS[0].id}
+                  image={newsItem.image}
+                  title={newsItem.title}
+                  description={newsItem.description}
+                  publishedTime={newsItem.publishedTime}
+                  newspaperCompany={newsItem.newspaperCompany}
+                  variant={newsItem.variant}
+                  key={newsItem.title}
+                />
+              </div>
+            </Link>
           ))}
         </ul>
       </div>

--- a/src/app/(news)/news/_components/NewsInfinityList.tsx
+++ b/src/app/(news)/news/_components/NewsInfinityList.tsx
@@ -1,5 +1,7 @@
 import NewsItem, { TINewsItemProps } from "@/components/common/List/NewsItem";
+import { NEWS_PATH } from "@/routes/path";
 import { cn } from "@/utils/cn";
+import Link from "next/link";
 import { Fragment, useEffect, useRef } from "react";
 
 type TINewsListProps = {
@@ -67,8 +69,9 @@ export default function NewsInfinityList({
       className={cn(`flex w-full flex-col overflow-y-scroll scrollbar-hide ${selectedVariantStyles.border} ${style}`)}
     >
       {newsItems?.map((newsItem, index) => (
-        <Fragment key={index}>
+        <Link key={index} href={`${NEWS_PATH}/${newsItem.id}`}>
           <NewsItem
+            id={newsItem.id}
             image={newsItem.image}
             title={newsItem.title}
             description={newsItem.description}
@@ -79,7 +82,7 @@ export default function NewsInfinityList({
           />
           {index === newsItems.length - 1 && <div ref={lastNewsItemRef} />}
           {index < newsItems.length - 1 && <hr />}
-        </Fragment>
+        </Link>
       ))}
     </div>
   );

--- a/src/app/(news)/news/_components/index.tsx
+++ b/src/app/(news)/news/_components/index.tsx
@@ -5,6 +5,21 @@ import NewsInfinityList from "@/app/(news)/news/_components/NewsInfinityList";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import PopularNews from "@/components/common/PopularNews";
+import NewsImage from "@/public/icons/news.jpg";
+import Link from "next/link";
+import { NEWS_PATH } from "@/routes/path";
+import Loading from "@/app/loading";
+
+const DUMMY_NEWS_ITEMS = Array(3).fill({
+  id: Math.floor(Math.random() * 100),
+  image: NewsImage,
+  title: "엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이",
+  description: `윤석열 대통령이 "포항 앞바다에 막대한 양의 석유·천연가스 매장 가능성이 있다"고 발표하면서 석유주가 이틀째 급등했다.3일 한국석유(004090)는 전일대비 5350원(29.81%) 오른 2만3300원에 거래를 마쳤다. 한국석유는 전날에도 상한가로 장을 마친 바 있다.이 외에도 한국ANKOR유전도 상한가를 찍었고, 흥구석유(024060)는 18.40% 올랐다.윤석열 대통령은 전날 용산 대통령실에서 열린 국정 브리핑에서 "포항 영일만 앞바다에 막대한 양의 석유와 가스가 매장돼 있을 가능성이 높다는 물리탐사 결과가 나왔다"고 밝혔다.매장량은 최대 140억 배럴 가능성이 예상되며 천연가스는 29년, 석유는 4년 이상 사용할 양이라고 설명했다.`,
+  publishedTime: "7",
+  newspaperCompany: "문화일보",
+  variant: "lineClamp-4",
+  date: "7시간전",
+});
 
 export default function News({}) {
   const [currentPage, setCurrentPage] = useState(1);
@@ -33,7 +48,7 @@ export default function News({}) {
   };
 
   if (status === "pending") {
-    return <p>Loading...</p>;
+    return <Loading />;
   }
   const allNews = data?.pages.flatMap((page) => page.data);
 
@@ -42,7 +57,21 @@ export default function News({}) {
       <PopularNews />
       <div className="flex w-full flex-col gap-[2.4rem]">
         <h2 className="heading_4 font-bold text-navy-900">관심종목과 관련된 뉴스</h2>
-        <div className="flex gap-[2rem]">{Array(3).fill(<Card variant="halfMediaCard" style="w-1/3" />)}</div>
+        <div className="flex gap-[2rem]">
+          {DUMMY_NEWS_ITEMS.map((news, index) => (
+            <Link key={index} href={`${NEWS_PATH}/${news.id}`}>
+              <Card
+                variant="halfMediaCard"
+                style="w-1/3"
+                date={news.date}
+                title={news.title}
+                image={news.image}
+                content={news.description}
+                publisher={news.newspaperCompany}
+              />
+            </Link>
+          ))}
+        </div>
       </div>
       <div className="flex w-full flex-col gap-[2.4rem]">
         <h2 className="heading_4 font-bold text-navy-900">최신 뉴스</h2>

--- a/src/components/common/List/NewsItem.tsx
+++ b/src/components/common/List/NewsItem.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/utils/cn";
 import Image, { StaticImageData } from "next/image";
 
 export type TINewsItemProps = {
+  id: number;
   image: StaticImageData;
   title: string;
   description: string;

--- a/src/components/common/PoPularNews.tsx
+++ b/src/components/common/PoPularNews.tsx
@@ -1,38 +1,46 @@
+import { NEWS_PATH } from "@/routes/path";
 import Card from "./Card";
+import Link from "next/link";
 
 const PopularNews = () => {
   return (
     <div className="flex flex-col gap-[2.4rem]">
       <h2 className="heading_4 font-bold text-navy-900">오늘 인기있는 뉴스</h2>
       <div className="flex min-w-[120px] gap-[2rem]">
-        <Card
-          image="/icons/news.jpg"
-          variant="fullMediaCard"
-          title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
-          content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
-          date="2024.06.05"
-          publisher="문화일보"
-          style="w-1/2"
-        />
+        <Link href={`${NEWS_PATH}/1`}>
+          <Card
+            image="/icons/news.jpg"
+            variant="fullMediaCard"
+            title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
+            content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
+            date="2024.06.05"
+            publisher="문화일보"
+            style="w-1/2"
+          />
+        </Link>
         <div className="flex w-1/2 flex-col gap-[2rem]">
-          <Card
-            image="/icons/news.jpg"
-            variant="fullMediaCard"
-            title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
-            content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
-            date="2024.06.05"
-            publisher="문화일보"
-            size="small"
-          />
-          <Card
-            image="/icons/news.jpg"
-            variant="fullMediaCard"
-            title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
-            content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
-            date="2024.06.05"
-            publisher="문화일보"
-            size="small"
-          />
+          <Link href={`${NEWS_PATH}/2`}>
+            <Card
+              image="/icons/news.jpg"
+              variant="fullMediaCard"
+              title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
+              content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
+              date="2024.06.05"
+              publisher="문화일보"
+              size="small"
+            />
+          </Link>
+          <Link href={`${NEWS_PATH}/3`}>
+            <Card
+              image="/icons/news.jpg"
+              variant="fullMediaCard"
+              title="엔비디아 또 신고가… 시총 2위 애플과 962억달러 차이"
+              content="엔비디아가 기존 주식을 10주로 쪼개는 액면분할을 3일 앞둔 4일(현지시간) 주당 신고가 기록을 다시 쓰며 고가 우려를 털어냈다. 차세대 인공지능(AI) GPU 발표..."
+              date="2024.06.05"
+              publisher="문화일보"
+              size="small"
+            />
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 기능 설명

<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업
- [x] 헤더 컴포넌트 구현
-->

## 📌 구현 내용

<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다.
-->

뉴스 페이지의 카드에 더미데이터를 넣어줬습니다.
뉴스 상세 페이지로 이동하는 부분은 Link태그로 감싸줬습니다. 


## 📌 구현 결과

<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점

<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요?
-->

근데 PopularNews컴포넌트에 Link컴포넌트로 감싸준 부분이 동작을 안하는데 더 찾아보겠습니다!
공통 컴포넌트 내부에서 Link태그로 감싸도록 추후 리팩토링하겠습니다!