### PR TITLE
[QJ5-93] 마이페이지 이용약관 API 호출 및 데이터 적용

### DIFF
--- a/src/app/[lang]/(mypage)/mypage/_components/PolicyContent.tsx
+++ b/src/app/[lang]/(mypage)/mypage/_components/PolicyContent.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/utils/cn";
 type TPolicyDivProps = {
   policyType: "service" | "privacy";
   handleToggleExpand: (policyType: "service" | "privacy") => void;
-  policyText: string;
+  policyText: JSX.Element[];
   expanded: boolean;
 };
 
@@ -30,7 +30,7 @@ export const PolicyContent = ({ policyType, handleToggleExpand, policyText, expa
           `rounded-[1.6rem] border border-gray-100 px-[1.4rem] py-[2.4rem] scrollbar-hide ${expanded ? "h-[100%]" : "h-[25rem] overflow-hidden overflow-y-scroll"}`,
         )}
       >
-        <pre className="body_4 text-wrap font-pretendard text-grayscale-900">{policyText}</pre>
+        <div className="body_4 text-wrap text-grayscale-900">{policyText}</div>
       </div>
     </article>
   );

--- a/src/app/[lang]/(mypage)/mypage/_components/PolicyContent.tsx
+++ b/src/app/[lang]/(mypage)/mypage/_components/PolicyContent.tsx
@@ -30,7 +30,9 @@ export const PolicyContent = ({ policyType, handleToggleExpand, policyText, expa
           `rounded-[1.6rem] border border-gray-100 px-[1.4rem] py-[2.4rem] scrollbar-hide ${expanded ? "h-[100%]" : "h-[25rem] overflow-hidden overflow-y-scroll"}`,
         )}
       >
-        <div className="body_4 text-wrap text-grayscale-900">{policyText}</div>
+        <div className="body_4 text-wrap text-grayscale-900">
+          <pre className="font-pretendard">{policyText}</pre>
+        </div>
       </div>
     </article>
   );

--- a/src/app/[lang]/(mypage)/mypage/_components/PolicyMain.tsx
+++ b/src/app/[lang]/(mypage)/mypage/_components/PolicyMain.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React, { useState } from "react";
+import { PolicyContent } from "./index";
+import { formatTextWithLineBreaks } from "@/utils/textUtils";
+
+type TPolicyTextProps = {
+  serviceText: string;
+  privacyText: string;
+};
+
+export default function TermsMain({ serviceText, privacyText }: TPolicyTextProps) {
+  const [servicePolicy, setServicePolicy] = useState(false);
+  const [privacyPolicy, setPrivacyPolicy] = useState(false);
+
+  const handleToggleExpand = (id: string) => {
+    if (id === "service") {
+      setServicePolicy((prev) => !prev);
+    } else if (id === "privacy") {
+      setPrivacyPolicy((prev) => !prev);
+    }
+  };
+
+  return (
+    <section className="flex w-[100%] flex-col gap-[5.4rem]">
+      <PolicyContent
+        policyType="service"
+        handleToggleExpand={handleToggleExpand}
+        policyText={formatTextWithLineBreaks(serviceText)}
+        expanded={servicePolicy}
+      />
+      <PolicyContent
+        policyType="privacy"
+        handleToggleExpand={handleToggleExpand}
+        policyText={formatTextWithLineBreaks(privacyText)}
+        expanded={privacyPolicy}
+      />
+    </section>
+  );
+}

--- a/src/app/[lang]/(mypage)/mypage/terms/page.tsx
+++ b/src/app/[lang]/(mypage)/mypage/terms/page.tsx
@@ -14,8 +14,7 @@ export default function Terms() {
   useEffect(() => {
     const fetchTerms = async () => {
       try {
-        // TODO: 백엔드 도메인 상수화
-        const response = await (await fetch("http://localhost:8080/api/terms/getTerms")).json();
+        const response = await (await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/terms/getTerms`)).json();
 
         if (response.ok) {
           setServicePolicyText(response.data.terms_of_service.content);
@@ -25,7 +24,7 @@ export default function Terms() {
         // TODO: API 호출 실패 시, Alert 처리 (혹은 프론트엔드 약관 파일로 대체)
         console.log("이용약관을 불러오지 못했습니다.", response);
       } catch (err) {
-        console.error("이용약관을 불러오지 못했습니다.", err);
+        console.log("이용약관을 불러오지 못했습니다.", err);
       }
     };
 

--- a/src/app/[lang]/(mypage)/mypage/terms/page.tsx
+++ b/src/app/[lang]/(mypage)/mypage/terms/page.tsx
@@ -3,6 +3,8 @@
 import React, { useEffect, useState } from "react";
 import { PolicyContent } from "../_components/index";
 import { formatTextWithLineBreaks } from "@/utils/textUtils";
+import { servicePolicyText as frontServicePolicyText } from "@/constants/servicePolicyText";
+import { privacyPolicyText as frontPrivacyPolicyText } from "@/constants/privacyPolicyText";
 
 export default function Terms() {
   const [servicePolicy, setServicePolicy] = useState(false);
@@ -19,13 +21,12 @@ export default function Terms() {
         if (response.ok) {
           setServicePolicyText(response.data.terms_of_service.content);
           setPrivacyPolicyText(response.data.privacy_policy.content);
-          return;
         }
-        // TODO: API 호출 실패 시, Alert 처리 (혹은 프론트엔드 약관 파일로 대체)
-        console.log("이용약관을 불러오지 못했습니다.", response);
       } catch (err) {
-        console.log("이용약관을 불러오지 못했습니다.", err);
+        console.error("이용약관 로드에 실패했습니다.", err);
       }
+      setServicePolicyText(frontServicePolicyText);
+      setPrivacyPolicyText(frontPrivacyPolicyText);
     };
 
     fetchTerms();

--- a/src/app/[lang]/(mypage)/mypage/terms/page.tsx
+++ b/src/app/[lang]/(mypage)/mypage/terms/page.tsx
@@ -1,13 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { PolicyContent } from "../_components/index";
-import { servicePolicyText } from "@/constants/servicePolicyText";
-import { privacyPolicyText } from "@/constants/privacyPolicyText";
+import { formatTextWithLineBreaks } from "@/utils/textUtils";
 
 export default function Terms() {
   const [servicePolicy, setServicePolicy] = useState(false);
   const [privacyPolicy, setPrivacyPolicy] = useState(false);
+
+  const [servicePolicyText, setServicePolicyText] = useState("");
+  const [privacyPolicyText, setPrivacyPolicyText] = useState("");
+
+  useEffect(() => {
+    const fetchTerms = async () => {
+      try {
+        // TODO: 백엔드 도메인 상수화
+        const response = await (await fetch("http://localhost:8080/api/terms/getTerms")).json();
+
+        if (response.ok) {
+          setServicePolicyText(response.data.terms_of_service.content);
+          setPrivacyPolicyText(response.data.privacy_policy.content);
+          return;
+        }
+        // TODO: API 호출 실패 시, Alert 처리 (혹은 프론트엔드 약관 파일로 대체)
+        console.log("이용약관을 불러오지 못했습니다.", response);
+      } catch (err) {
+        console.error("이용약관을 불러오지 못했습니다.", err);
+      }
+    };
+
+    fetchTerms();
+  }, []);
 
   const handleToggleExpand = (id: string) => {
     if (id === "service") {
@@ -22,13 +45,13 @@ export default function Terms() {
       <PolicyContent
         policyType="service"
         handleToggleExpand={handleToggleExpand}
-        policyText={servicePolicyText}
+        policyText={formatTextWithLineBreaks(servicePolicyText)}
         expanded={servicePolicy}
       />
       <PolicyContent
         policyType="privacy"
         handleToggleExpand={handleToggleExpand}
-        policyText={privacyPolicyText}
+        policyText={formatTextWithLineBreaks(privacyPolicyText)}
         expanded={privacyPolicy}
       />
     </section>

--- a/src/app/[lang]/(mypage)/mypage/terms/page.tsx
+++ b/src/app/[lang]/(mypage)/mypage/terms/page.tsx
@@ -1,59 +1,27 @@
-"use client";
+import React from "react";
+import TermsMain from "../_components/PolicyMain";
+import { servicePolicyText } from "@/constants/servicePolicyText";
+import { privacyPolicyText } from "@/constants/privacyPolicyText";
 
-import React, { useEffect, useState } from "react";
-import { PolicyContent } from "../_components/index";
-import { formatTextWithLineBreaks } from "@/utils/textUtils";
-import { servicePolicyText as frontServicePolicyText } from "@/constants/servicePolicyText";
-import { privacyPolicyText as frontPrivacyPolicyText } from "@/constants/privacyPolicyText";
+const getTerms = async () => {
+  try {
+    const response = await (await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/terms/getTerms`)).json();
 
-export default function Terms() {
-  const [servicePolicy, setServicePolicy] = useState(false);
-  const [privacyPolicy, setPrivacyPolicy] = useState(false);
-
-  const [servicePolicyText, setServicePolicyText] = useState("");
-  const [privacyPolicyText, setPrivacyPolicyText] = useState("");
-
-  useEffect(() => {
-    const fetchTerms = async () => {
-      try {
-        const response = await (await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/terms/getTerms`)).json();
-
-        if (response.ok) {
-          setServicePolicyText(response.data.terms_of_service.content);
-          setPrivacyPolicyText(response.data.privacy_policy.content);
-        }
-      } catch (err) {
-        console.error("이용약관 로드에 실패했습니다.", err);
-      }
-      setServicePolicyText(frontServicePolicyText);
-      setPrivacyPolicyText(frontPrivacyPolicyText);
-    };
-
-    fetchTerms();
-  }, []);
-
-  const handleToggleExpand = (id: string) => {
-    if (id === "service") {
-      setServicePolicy((prev) => !prev);
-    } else if (id === "privacy") {
-      setPrivacyPolicy((prev) => !prev);
+    if (response.ok) {
+      return response.data;
     }
-  };
+  } catch (err) {
+    console.error("이용약관을 가져오는 데 실패했습니다.");
+    return null;
+  }
+};
 
+export default async function Terms() {
+  const policyText = await getTerms();
   return (
-    <section className="flex w-[100%] flex-col gap-[5.4rem]">
-      <PolicyContent
-        policyType="service"
-        handleToggleExpand={handleToggleExpand}
-        policyText={formatTextWithLineBreaks(servicePolicyText)}
-        expanded={servicePolicy}
-      />
-      <PolicyContent
-        policyType="privacy"
-        handleToggleExpand={handleToggleExpand}
-        policyText={formatTextWithLineBreaks(privacyPolicyText)}
-        expanded={privacyPolicy}
-      />
-    </section>
+    <TermsMain
+      serviceText={policyText ? policyText.terms_of_service.content : servicePolicyText}
+      privacyText={policyText ? policyText.privacy_policy.content : privacyPolicyText}
+    />
   );
 }

--- a/src/utils/textUtils.tsx
+++ b/src/utils/textUtils.tsx
@@ -1,0 +1,8 @@
+export const formatTextWithLineBreaks = (text: string) => {
+  return text.split("\\n").map((line, index) => (
+    <span key={index}>
+      {line}
+      <br />
+    </span>
+  ));
+};


### PR DESCRIPTION
## 📌 기능 설명

- [x] 마이페이지 이용약관 데이터 API 호출 및 데이터 적용

## 📌 구현 내용

- API를 이용해 이용약관을 DB에서 호출했습니다.
- 데이터의 개행 문자열을 적절히 처리하여 출력했습니다.

## 📌 구현 결과

![image](https://github.com/doksuri5/frontend/assets/51500821/1b342587-b94e-4fee-8f47-a81c1023321c)


## 📌 논의하고 싶은 점

- API 호출 실패 시, Alert로 `이용약관을 불러오지 못했습니다.`라는 문구를 유저에게 보여줄지, 혹은 기존에 존재하는 프론트엔드 약관 텍스트로 대체해서 보여줄지 고민입니다.🤔
- 백엔드 URL은 `NEXT_PUBLIC_API_BASE_URL`로 대체하여 작성했습니다. `.env` 파일에 `NEXT_PUBLIC_API_BASE_URL=http://localhost:8080` 추가해 주시면 정상적으로 API 호출이 가능합니다.
