### PR TITLE
[QJ5-92] 주식 데이터에서 중립이 있을 경우 처리 추가, 주식 데이터 포맷팅 관련 함수 리팩터링

### DIFF
--- a/src/app/[lang]/(home)/home/_components/SimpleReportCard.tsx
+++ b/src/app/[lang]/(home)/home/_components/SimpleReportCard.tsx
@@ -1,5 +1,6 @@
 import SimpleRadarChart from "@/components/common/SimpleRadarChart";
 import { cn } from "@/utils/cn";
+import { formatValueWithIndicator, formatValueWithSign, getTextColor } from "@/utils/stockPriceUtils";
 import Image from "next/image";
 import { useCallback, useMemo } from "react";
 
@@ -28,8 +29,8 @@ const DUMMY_REPORTS = {
 const SimpleReportCard = ({ report }: { report: TReport }) => {
   const { companyName, stockCode, currentPrice, fluctuationPrice, fluctuationRatio } = report;
 
-  const fluctuationColor = fluctuationRatio < 0 ? "text-blue-600" : "text-warning-100";
-  const fluctuationArrow = fluctuationRatio < 0 ? "▼" : "▲";
+  const fluctuationColor = getTextColor(fluctuationRatio);
+  //const fluctuationArrow = fluctuationRatio < 0 ? "▼" : "▲";
 
   const changeArrow = useCallback((ratio: number) => {
     return ratio < 0 ? "▼" : "▲";
@@ -47,8 +48,8 @@ const SimpleReportCard = ({ report }: { report: TReport }) => {
           <span>${currentPrice}</span>
         </div>
         <div className={cn("body_4 flex gap-[0.8rem] font-normal", fluctuationColor)}>
-          <span>{fluctuationArrow + fluctuationPrice}</span>
-          <span>{fluctuationRatio}%</span>
+          <span>{formatValueWithIndicator(fluctuationPrice)}</span>
+          <span>{formatValueWithSign(fluctuationRatio)}%</span>
         </div>
       </div>
       <div className="flex h-full w-full items-center gap-[0.8rem]">
@@ -59,31 +60,31 @@ const SimpleReportCard = ({ report }: { report: TReport }) => {
           <li className="flex justify-between">
             주가
             <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-              <span>{fluctuationArrow + fluctuationRatio}%</span>
+              <span>{formatValueWithIndicator(fluctuationRatio)}%</span>
             </div>
           </li>
           <li className="flex justify-between">
             투자지수
             <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-              <span>{fluctuationArrow + fluctuationRatio}%</span>
+              <span>{formatValueWithIndicator(fluctuationRatio)}%</span>
             </div>
           </li>
           <li className="flex justify-between">
             수익성
             <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-              <span>{fluctuationArrow + fluctuationRatio}%</span>
+              <span>{formatValueWithIndicator(fluctuationRatio)}%</span>
             </div>
           </li>
           <li className="flex justify-between">
             성장성
             <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-              <span>{fluctuationArrow + fluctuationRatio}%</span>
+              <span>{formatValueWithIndicator(fluctuationRatio)}%</span>
             </div>
           </li>
           <li className="flex justify-between">
             관심도
             <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-              <span>{fluctuationArrow + fluctuationRatio}%</span>
+              <span>{formatValueWithIndicator(fluctuationRatio)}%</span>
             </div>
           </li>
         </ul>

--- a/src/app/[lang]/(home)/home/_components/SimpleReportCard.tsx
+++ b/src/app/[lang]/(home)/home/_components/SimpleReportCard.tsx
@@ -30,11 +30,6 @@ const SimpleReportCard = ({ report }: { report: TReport }) => {
   const { companyName, stockCode, currentPrice, fluctuationPrice, fluctuationRatio } = report;
 
   const fluctuationColor = getTextColor(fluctuationRatio);
-  //const fluctuationArrow = fluctuationRatio < 0 ? "▼" : "▲";
-
-  const changeArrow = useCallback((ratio: number) => {
-    return ratio < 0 ? "▼" : "▲";
-  }, []);
 
   return (
     <section className="h-[28rem] flex-1 rounded-[1.6rem] bg-white p-[3.2rem]">

--- a/src/app/[lang]/(mystock)/mystock/_components/MyStockItem.tsx
+++ b/src/app/[lang]/(mystock)/mystock/_components/MyStockItem.tsx
@@ -8,7 +8,7 @@ import {
   getCompareToPreviousClosePriceColor,
   getFluctuationsRatioColor,
   getCompareToPreviousClosePriceArrow,
-  getCompareToPreviousClosePriceSign,
+  getAbsoluteCompareToPreviousClosePrice,
   getFluctuationsRatioSign,
 } from "@/utils/stockPriceUtils";
 import graph from "@/public/icons/graph.png";
@@ -53,7 +53,7 @@ const MyStockItem = ({ data }: TMyStockItemProps) => {
           <span className="body_4 font-medium text-grayscale-900">{`${cashSymbol.get(data.nationType) || ""}${data.price}`}</span>
           <span className={`${getCompareToPreviousClosePriceColor(data.compareToPreviousClosePrice)}`}>
             {getCompareToPreviousClosePriceArrow(data.compareToPreviousClosePrice)}
-            {getCompareToPreviousClosePriceSign(data.compareToPreviousClosePrice)}
+            {getAbsoluteCompareToPreviousClosePrice(data.compareToPreviousClosePrice)}
           </span>
           <span className={`${getFluctuationsRatioColor(data.fluctuationsRatio)}`}>
             {getFluctuationsRatioSign(data.fluctuationsRatio) + data.fluctuationsRatio + "%"}

--- a/src/app/[lang]/(mystock)/mystock/_components/MyStockItem.tsx
+++ b/src/app/[lang]/(mystock)/mystock/_components/MyStockItem.tsx
@@ -4,13 +4,7 @@ import { useState } from "react";
 import Image from "next/image";
 import { Alert, Button } from "@/components/common";
 import { StockDataType } from "@/types";
-import {
-  getCompareToPreviousClosePriceColor,
-  getFluctuationsRatioColor,
-  getCompareToPreviousClosePriceArrow,
-  getAbsoluteCompareToPreviousClosePrice,
-  getFluctuationsRatioSign,
-} from "@/utils/stockPriceUtils";
+import { formatValueWithIndicator, formatValueWithSign, getTextColor } from "@/utils/stockPriceUtils";
 import graph from "@/public/icons/graph.png";
 import Link from "next/link";
 import { REPORT_PATH } from "@/routes/path";
@@ -51,12 +45,11 @@ const MyStockItem = ({ data }: TMyStockItemProps) => {
         </div>
         <div className="flex_row justify-start gap-[.8rem]">
           <span className="body_4 font-medium text-grayscale-900">{`${cashSymbol.get(data.nationType) || ""}${data.price}`}</span>
-          <span className={`${getCompareToPreviousClosePriceColor(data.compareToPreviousClosePrice)}`}>
-            {getCompareToPreviousClosePriceArrow(data.compareToPreviousClosePrice)}
-            {getAbsoluteCompareToPreviousClosePrice(data.compareToPreviousClosePrice)}
+          <span className={`${getTextColor(data.compareToPreviousClosePrice)}`}>
+            {formatValueWithIndicator(data.compareToPreviousClosePrice)}
           </span>
-          <span className={`${getFluctuationsRatioColor(data.fluctuationsRatio)}`}>
-            {getFluctuationsRatioSign(data.fluctuationsRatio) + data.fluctuationsRatio + "%"}
+          <span className={`${getTextColor(data.fluctuationsRatio)}`}>
+            {formatValueWithSign(data.fluctuationsRatio) + "%"}
           </span>
         </div>
       </div>

--- a/src/app/[lang]/(mystock)/mystock/_components/MyStockPopularSearches.tsx
+++ b/src/app/[lang]/(mystock)/mystock/_components/MyStockPopularSearches.tsx
@@ -4,7 +4,7 @@ import {
   getCompareToPreviousClosePriceColor,
   getFluctuationsRatioColor,
   getCompareToPreviousClosePriceArrow,
-  getCompareToPreviousClosePriceSign,
+  getAbsoluteCompareToPreviousClosePrice,
   getFluctuationsRatioSign,
 } from "@/utils/stockPriceUtils";
 import Apple_icon from "@/public/icons/Apple_icon.svg";
@@ -87,7 +87,7 @@ const MyStockPopularSearches = () => {
             <div>
               <span className={`${getCompareToPreviousClosePriceColor(popular.compareToPreviousClosePrice)}`}>
                 {getCompareToPreviousClosePriceArrow(popular.compareToPreviousClosePrice)}
-                {getCompareToPreviousClosePriceSign(popular.compareToPreviousClosePrice)}
+                {getAbsoluteCompareToPreviousClosePrice(popular.compareToPreviousClosePrice)}
               </span>
               <span className={`${getFluctuationsRatioColor(popular.fluctuationsRatio)}`}>
                 {getFluctuationsRatioSign(popular.fluctuationsRatio) + popular.fluctuationsRatio + "%"}

--- a/src/app/[lang]/(mystock)/mystock/_components/MyStockPopularSearches.tsx
+++ b/src/app/[lang]/(mystock)/mystock/_components/MyStockPopularSearches.tsx
@@ -1,12 +1,6 @@
 import Image from "next/image";
 import { PopularDetailDataType } from "@/types";
-import {
-  getCompareToPreviousClosePriceColor,
-  getFluctuationsRatioColor,
-  getCompareToPreviousClosePriceArrow,
-  getAbsoluteCompareToPreviousClosePrice,
-  getFluctuationsRatioSign,
-} from "@/utils/stockPriceUtils";
+import { formatValueWithIndicator, formatValueWithSign, getTextColor } from "@/utils/stockPriceUtils";
 import Apple_icon from "@/public/icons/Apple_icon.svg";
 
 const popularList: PopularDetailDataType[] = [
@@ -85,12 +79,11 @@ const MyStockPopularSearches = () => {
               <span className="body_4 w-full truncate font-medium text-grayscale-600">{popular.stockName}</span>
             </div>
             <div>
-              <span className={`${getCompareToPreviousClosePriceColor(popular.compareToPreviousClosePrice)}`}>
-                {getCompareToPreviousClosePriceArrow(popular.compareToPreviousClosePrice)}
-                {getAbsoluteCompareToPreviousClosePrice(popular.compareToPreviousClosePrice)}
+              <span className={`${getTextColor(popular.compareToPreviousClosePrice)}`}>
+                {formatValueWithIndicator(popular.compareToPreviousClosePrice)}
               </span>
-              <span className={`${getFluctuationsRatioColor(popular.fluctuationsRatio)}`}>
-                {getFluctuationsRatioSign(popular.fluctuationsRatio) + popular.fluctuationsRatio + "%"}
+              <span className={`${getTextColor(popular.fluctuationsRatio)}`}>
+                {formatValueWithSign(popular.fluctuationsRatio) + "%"}
               </span>
             </div>
           </div>

--- a/src/app/[lang]/(mystock)/mystock/_components/SearchItem.tsx
+++ b/src/app/[lang]/(mystock)/mystock/_components/SearchItem.tsx
@@ -7,7 +7,7 @@ import { StockDataType } from "@/types";
 import {
   getCompareToPreviousClosePriceColor,
   getCompareToPreviousClosePriceArrow,
-  getCompareToPreviousClosePriceSign,
+  getAbsoluteCompareToPreviousClosePrice,
   getFluctuationsRatioColor,
   getFluctuationsRatioSign,
 } from "@/utils/stockPriceUtils";
@@ -53,7 +53,7 @@ const SearchItem = ({ data }: TSearchItemProps) => {
           <span className="body_4 font-medium text-grayscale-900">{`${cashSymbol.get(data.nationType) || ""}${data.price}`}</span>
           <span className={`${getCompareToPreviousClosePriceColor(data.compareToPreviousClosePrice)}`}>
             {getCompareToPreviousClosePriceArrow(data.compareToPreviousClosePrice)}
-            {getCompareToPreviousClosePriceSign(data.compareToPreviousClosePrice)}
+            {getAbsoluteCompareToPreviousClosePrice(data.compareToPreviousClosePrice)}
           </span>
           <span className={`${getFluctuationsRatioColor(data.fluctuationsRatio)}`}>
             {getFluctuationsRatioSign(data.fluctuationsRatio) + data.fluctuationsRatio + "%"}

--- a/src/app/[lang]/(mystock)/mystock/_components/SearchItem.tsx
+++ b/src/app/[lang]/(mystock)/mystock/_components/SearchItem.tsx
@@ -4,13 +4,7 @@ import Image from "next/image";
 import { Button } from "@/components/common";
 import { useInterestStockStore } from "@/app/[lang]/(mystock)/mystock/stores";
 import { StockDataType } from "@/types";
-import {
-  getCompareToPreviousClosePriceColor,
-  getCompareToPreviousClosePriceArrow,
-  getAbsoluteCompareToPreviousClosePrice,
-  getFluctuationsRatioColor,
-  getFluctuationsRatioSign,
-} from "@/utils/stockPriceUtils";
+import { formatValueWithIndicator, formatValueWithSign, getTextColor } from "@/utils/stockPriceUtils";
 
 type TSearchItemProps = {
   data: StockDataType;
@@ -51,12 +45,11 @@ const SearchItem = ({ data }: TSearchItemProps) => {
       <div className="flex_row gap-[2rem]">
         <div className="flex_row gap-[.8rem]">
           <span className="body_4 font-medium text-grayscale-900">{`${cashSymbol.get(data.nationType) || ""}${data.price}`}</span>
-          <span className={`${getCompareToPreviousClosePriceColor(data.compareToPreviousClosePrice)}`}>
-            {getCompareToPreviousClosePriceArrow(data.compareToPreviousClosePrice)}
-            {getAbsoluteCompareToPreviousClosePrice(data.compareToPreviousClosePrice)}
+          <span className={`${getTextColor(data.compareToPreviousClosePrice)}`}>
+            {formatValueWithIndicator(data.compareToPreviousClosePrice)}
           </span>
-          <span className={`${getFluctuationsRatioColor(data.fluctuationsRatio)}`}>
-            {getFluctuationsRatioSign(data.fluctuationsRatio) + data.fluctuationsRatio + "%"}
+          <span className={`${getTextColor(data.fluctuationsRatio)}`}>
+            {formatValueWithSign(data.fluctuationsRatio) + "%"}
           </span>
         </div>
         {isStockItemListContainsData ? (

--- a/src/app/[lang]/(report)/report/_components/AIAnalystReport.tsx
+++ b/src/app/[lang]/(report)/report/_components/AIAnalystReport.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/utils/cn";
-import { getCompareToPreviousClosePriceArrow, getFluctuationsRatioColor } from "@/utils/stockPriceUtils";
+import { formatValueWithIndicator, formatValueWithSign, getTextColor } from "@/utils/stockPriceUtils";
 import Image from "next/image";
 
 type TAIAnalystReport = {
@@ -16,8 +16,6 @@ type TAIAnalystReport = {
 
 export default function AIAnalystReport({ data }: TAIAnalystReport) {
   const { icon, stockName, symbolCode, priceUSD, aiReport, fluctuationsRatio, compareToPreviousClosePrice } = data;
-  const fluctuationColor = getFluctuationsRatioColor(fluctuationsRatio); // "text-grayscale-500"; //`text-[#7d7d7d]`; // getFluctuationsRatioColor(fluctuationsRatio);
-  const fluctuationArrow = getCompareToPreviousClosePriceArrow(fluctuationsRatio);
 
   return (
     <section className="min-h-[29.5rem] min-w-[75rem] rounded-[1.6rem] bg-white p-[3.2rem]">
@@ -29,9 +27,9 @@ export default function AIAnalystReport({ data }: TAIAnalystReport) {
         <div className="body_4 font-medium">
           <span>${priceUSD}</span>
         </div>
-        <div className={cn(`body_4 flex gap-[0.8rem] font-normal ${fluctuationColor}`)}>
-          <span>{fluctuationArrow + compareToPreviousClosePrice}</span>
-          <span>{fluctuationsRatio}%</span>
+        <div className={cn(`body_4 flex gap-[0.8rem] font-normal ${getTextColor(fluctuationsRatio)}`)}>
+          <span>{formatValueWithIndicator(compareToPreviousClosePrice)}</span>
+          <span>{formatValueWithSign(fluctuationsRatio)}%</span>
         </div>
       </div>
       <p className="body_4 font-medium">{aiReport}</p>

--- a/src/app/[lang]/(report)/report/_components/AIAnalystReport.tsx
+++ b/src/app/[lang]/(report)/report/_components/AIAnalystReport.tsx
@@ -35,7 +35,6 @@ export default function AIAnalystReport({ data }: TAIAnalystReport) {
         </div>
       </div>
       <p className="body_4 font-medium">{aiReport}</p>
-      <div className="flex items-center gap-[0.8rem]"></div>
     </section>
   );
 }

--- a/src/app/[lang]/(report)/report/_components/AIAnalystReport.tsx
+++ b/src/app/[lang]/(report)/report/_components/AIAnalystReport.tsx
@@ -1,11 +1,12 @@
 import { cn } from "@/utils/cn";
+import { getCompareToPreviousClosePriceArrow, getFluctuationsRatioColor } from "@/utils/stockPriceUtils";
 import Image from "next/image";
 
 type TAIAnalystReport = {
   data: {
     icon: string;
     stockName: string;
-    stockCode: string;
+    symbolCode: string;
     priceUSD: number;
     aiReport: string;
     fluctuationsRatio: number;
@@ -14,23 +15,23 @@ type TAIAnalystReport = {
 };
 
 export default function AIAnalystReport({ data }: TAIAnalystReport) {
-  const { icon, stockName, stockCode, priceUSD, aiReport, fluctuationsRatio, compareToPreviousClosePrice } = data;
-  const fluctuationColor = fluctuationsRatio < 0 ? "text-blue-600" : "text-warning-100";
-  const fluctuationArrow = fluctuationsRatio < 0 ? "▼" : "▲";
+  const { icon, stockName, symbolCode, priceUSD, aiReport, fluctuationsRatio, compareToPreviousClosePrice } = data;
+  const fluctuationColor = getFluctuationsRatioColor(fluctuationsRatio); // "text-grayscale-500"; //`text-[#7d7d7d]`; // getFluctuationsRatioColor(fluctuationsRatio);
+  const fluctuationArrow = getCompareToPreviousClosePriceArrow(fluctuationsRatio);
 
   return (
     <section className="min-h-[29.5rem] min-w-[75rem] rounded-[1.6rem] bg-white p-[3.2rem]">
       <h2 className="body_1 pb-[5.5rem] font-bold text-navy-900">아잇나우 AI 애널리스트 리포트</h2>
-      <div className="mb-[1.6rem] flex items-center gap-[0.8rem]">
+      <div className="mb-[1.6rem] flex items-center gap-[0.8rem] text-grayscale-900">
         <Image src={icon} alt="icon" width={30} height={30} />
         <h3 className="body_3 font-bold">{stockName}</h3>
-        <h3 className="body_5 font-normal text-grayscale-600">{stockCode}</h3>
-        <div className="body_5 text-right font-medium">
+        <h3 className="body_3 font-normal">{symbolCode}</h3>
+        <div className="body_4 font-medium">
           <span>${priceUSD}</span>
         </div>
-        <div className={cn("body_4 flex gap-[0.8rem] font-normal", fluctuationColor)}>
+        <div className={cn(`body_4 flex gap-[0.8rem] font-normal ${fluctuationColor}`)}>
           <span>{fluctuationArrow + compareToPreviousClosePrice}</span>
-          <span>{priceUSD}%</span>
+          <span>{fluctuationsRatio}%</span>
         </div>
       </div>
       <p className="body_4 font-medium">{aiReport}</p>

--- a/src/app/[lang]/(report)/report/_components/StockAIReport.tsx
+++ b/src/app/[lang]/(report)/report/_components/StockAIReport.tsx
@@ -1,6 +1,6 @@
 import { SimpleRadarChart } from "@/components/common";
 import { cn } from "@/utils/cn";
-import { getCompareToPreviousClosePriceArrow, getFluctuationsRatioColor } from "@/utils/stockPriceUtils";
+import { formatValueWithIndicator, getTextColor } from "@/utils/stockPriceUtils";
 
 type StockAIReport = {
   data: {
@@ -11,9 +11,6 @@ type StockAIReport = {
 
 export default function StockAIReport({ data }: StockAIReport) {
   const { fluctuationsRatio, score } = data;
-
-  const fluctuationColor = getFluctuationsRatioColor(fluctuationsRatio);
-  const fluctuationArrow = getCompareToPreviousClosePriceArrow(fluctuationsRatio);
 
   return (
     <section className="min-h-[29.5rem] min-w-[43rem]">
@@ -29,32 +26,32 @@ export default function StockAIReport({ data }: StockAIReport) {
           <ul className="body_6 flex h-auto min-w-[14rem] flex-col gap-[0.4rem] rounded-[2.4rem] bg-[#F9F9F9] p-[1.6rem]">
             <li className="flex justify-between">
               주가
-              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-                <span>{fluctuationArrow + fluctuationsRatio}%</span>
+              <div className={cn("flex gap-[0.8rem] font-normal", getTextColor(fluctuationsRatio))}>
+                <span>{formatValueWithIndicator(fluctuationsRatio)}%</span>
               </div>
             </li>
             <li className="flex justify-between">
               투자지수
-              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-                <span>{fluctuationArrow + fluctuationsRatio}%</span>
+              <div className={cn("flex gap-[0.8rem] font-normal", getTextColor(fluctuationsRatio))}>
+                <span>{formatValueWithIndicator(fluctuationsRatio)}%</span>
               </div>
             </li>
             <li className="flex justify-between">
               수익성
-              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-                <span>{fluctuationArrow + fluctuationsRatio}%</span>
+              <div className={cn("flex gap-[0.8rem] font-normal", getTextColor(fluctuationsRatio))}>
+                <span>{formatValueWithIndicator(fluctuationsRatio)}%</span>
               </div>
             </li>
             <li className="flex justify-between">
               성장성
-              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-                <span>{fluctuationArrow + fluctuationsRatio}%</span>
+              <div className={cn("flex gap-[0.8rem] font-normal", getTextColor(fluctuationsRatio))}>
+                <span>{formatValueWithIndicator(fluctuationsRatio)}%</span>
               </div>
             </li>
             <li className="flex justify-between">
               관심도
-              <div className={cn("flex gap-[0.8rem] font-normal", fluctuationColor)}>
-                <span>{fluctuationArrow + fluctuationsRatio}%</span>
+              <div className={cn("flex gap-[0.8rem] font-normal", getTextColor(fluctuationsRatio))}>
+                <span>{formatValueWithIndicator(fluctuationsRatio)}%</span>
               </div>
             </li>
           </ul>

--- a/src/app/[lang]/(report)/report/_components/StockDetail.tsx
+++ b/src/app/[lang]/(report)/report/_components/StockDetail.tsx
@@ -3,7 +3,12 @@
 import { useState } from "react";
 import { Toggle } from "@/components/common";
 import { cn } from "@/utils/cn";
-import { getCompareToPreviousClosePriceArrow, getFluctuationsRatioColor } from "@/utils/stockPriceUtils";
+import {
+  getAbsoluteCompareToPreviousClosePrice,
+  getCompareToPreviousClosePriceArrow,
+  getFluctuationsRatioColor,
+  getFluctuationsRatioSign,
+} from "@/utils/stockPriceUtils";
 import { StockDetailDataType } from "@/types";
 
 type TStockDetail = {
@@ -16,8 +21,10 @@ export default function StockDetail({ stockDetail }: TStockDetail) {
     stockDetail;
 
   const fluctuationColor = getFluctuationsRatioColor(fluctuationsRatio);
-  const fluctuationArrow = getCompareToPreviousClosePriceArrow(fluctuationsRatio);
-  const fluctuationSign = fluctuationsRatio < 0 ? "-" : "+";
+  const fluctuationSign = getFluctuationsRatioSign(fluctuationsRatio);
+  const compareToPreviousClosePriceValue = getAbsoluteCompareToPreviousClosePrice(compareToPreviousClosePrice);
+  const compareToPreviousClosePriceArrow = getCompareToPreviousClosePriceArrow(compareToPreviousClosePrice);
+
   const viewCurrency = currency ? `$${priceUSD}` : `₩${price}`;
   const viewStockName = currency ? symbolCode : stockName;
 
@@ -33,7 +40,7 @@ export default function StockDetail({ stockDetail }: TStockDetail) {
                 <span className="body_2 font-normal">{viewStockName}</span>
               </div>
               <div className={cn(`flex_row body_2 gap-[0.8rem] font-normal ${fluctuationColor}`)}>
-                <span>{fluctuationArrow + compareToPreviousClosePrice}</span>
+                <span>{compareToPreviousClosePriceArrow + compareToPreviousClosePriceValue}</span>
                 <span>
                   {fluctuationSign}
                   {fluctuationsRatio}%

--- a/src/app/[lang]/(report)/report/_components/StockDetail.tsx
+++ b/src/app/[lang]/(report)/report/_components/StockDetail.tsx
@@ -3,13 +3,8 @@
 import { useState } from "react";
 import { Toggle } from "@/components/common";
 import { cn } from "@/utils/cn";
-import {
-  getAbsoluteCompareToPreviousClosePrice,
-  getCompareToPreviousClosePriceArrow,
-  getFluctuationsRatioColor,
-  getFluctuationsRatioSign,
-} from "@/utils/stockPriceUtils";
 import { StockDetailDataType } from "@/types";
+import { formatValueWithIndicator, formatValueWithSign, getTextColor } from "@/utils/stockPriceUtils";
 
 type TStockDetail = {
   stockDetail: Omit<StockDetailDataType, "_id" | "icon" | "score" | "stockCode" | "isMyStock" | "aiReport">;
@@ -19,11 +14,6 @@ export default function StockDetail({ stockDetail }: TStockDetail) {
   const [currency, setCurrency] = useState(false);
   const { priceUSD, price, symbolCode, stockName, compareToPreviousClosePrice, fluctuationsRatio, description } =
     stockDetail;
-
-  const fluctuationColor = getFluctuationsRatioColor(fluctuationsRatio);
-  const fluctuationSign = getFluctuationsRatioSign(fluctuationsRatio);
-  const compareToPreviousClosePriceValue = getAbsoluteCompareToPreviousClosePrice(compareToPreviousClosePrice);
-  const compareToPreviousClosePriceArrow = getCompareToPreviousClosePriceArrow(compareToPreviousClosePrice);
 
   const viewCurrency = currency ? `$${priceUSD}` : `₩${price}`;
   const viewStockName = currency ? symbolCode : stockName;
@@ -39,12 +29,9 @@ export default function StockDetail({ stockDetail }: TStockDetail) {
                 <span className="body_1 font-bold">∙</span>
                 <span className="body_2 font-normal">{viewStockName}</span>
               </div>
-              <div className={cn(`flex_row body_2 gap-[0.8rem] font-normal ${fluctuationColor}`)}>
-                <span>{compareToPreviousClosePriceArrow + compareToPreviousClosePriceValue}</span>
-                <span>
-                  {fluctuationSign}
-                  {fluctuationsRatio}%
-                </span>
+              <div className={cn(`flex_row body_2 gap-[0.8rem] font-normal ${getTextColor(fluctuationsRatio)}`)}>
+                <span>{formatValueWithIndicator(compareToPreviousClosePrice)}</span>
+                <span>{formatValueWithSign(fluctuationsRatio)}%</span>
               </div>
             </div>
             <Toggle checked={currency} setChecked={setCurrency} />

--- a/src/app/[lang]/(report)/report/_components/index.tsx
+++ b/src/app/[lang]/(report)/report/_components/index.tsx
@@ -89,7 +89,7 @@ export default function Report() {
           data={{
             icon,
             stockName,
-            stockCode,
+            symbolCode,
             priceUSD,
             aiReport,
             fluctuationsRatio,

--- a/src/components/common/List/StockItem.tsx
+++ b/src/components/common/List/StockItem.tsx
@@ -1,13 +1,7 @@
 import { DISCOVERY_PATH, REPORT_PATH } from "@/routes/path";
 import { StockDataType } from "@/types";
 import { cn } from "@/utils/cn";
-import {
-  getCompareToPreviousClosePriceColor,
-  getCompareToPreviousClosePriceArrow,
-  getAbsoluteCompareToPreviousClosePrice,
-  getFluctuationsRatioColor,
-  getFluctuationsRatioSign,
-} from "@/utils/stockPriceUtils";
+import { formatValueWithIndicator, formatValueWithSign, getTextColor } from "@/utils/stockPriceUtils";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -51,11 +45,7 @@ export default function StockItem({
   style,
   variant = "stock",
 }: TIStockItemProps) {
-  const fluctuationPriceColor = getCompareToPreviousClosePriceColor(compareToPreviousClosePrice);
-  const fluctuationRatioColor = getFluctuationsRatioColor(compareToPreviousClosePrice);
-  const fluctuationArrow = getCompareToPreviousClosePriceArrow(compareToPreviousClosePrice);
-  const fluctuationPriceSign = getAbsoluteCompareToPreviousClosePrice(compareToPreviousClosePrice);
-  const fluctuationRatioSign = getFluctuationsRatioSign(fluctuationsRatio);
+  const fluctuationPriceColor = getTextColor(compareToPreviousClosePrice);
 
   const selectedVariantStyles = variantStyles[variant];
 
@@ -80,8 +70,8 @@ export default function StockItem({
             <span>${price}</span>
           </div>
           <div className={cn(`${selectedVariantStyles.fluctuation}`)}>
-            <span className={`${fluctuationPriceColor}`}>{fluctuationArrow + fluctuationPriceSign}</span>
-            <span className={`${fluctuationRatioColor}`}>{fluctuationRatioSign + fluctuationsRatio}%</span>
+            <span className={`${fluctuationPriceColor}`}>{formatValueWithIndicator(compareToPreviousClosePrice)}</span>
+            <span className={`${fluctuationPriceColor}`}>{formatValueWithSign(fluctuationsRatio)}%</span>
           </div>
         </div>
       </div>

--- a/src/components/common/List/StockItem.tsx
+++ b/src/components/common/List/StockItem.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/utils/cn";
 import {
   getCompareToPreviousClosePriceColor,
   getCompareToPreviousClosePriceArrow,
-  getCompareToPreviousClosePriceSign,
+  getAbsoluteCompareToPreviousClosePrice,
   getFluctuationsRatioColor,
   getFluctuationsRatioSign,
 } from "@/utils/stockPriceUtils";
@@ -54,7 +54,7 @@ export default function StockItem({
   const fluctuationPriceColor = getCompareToPreviousClosePriceColor(compareToPreviousClosePrice);
   const fluctuationRatioColor = getFluctuationsRatioColor(compareToPreviousClosePrice);
   const fluctuationArrow = getCompareToPreviousClosePriceArrow(compareToPreviousClosePrice);
-  const fluctuationPriceSign = getCompareToPreviousClosePriceSign(compareToPreviousClosePrice);
+  const fluctuationPriceSign = getAbsoluteCompareToPreviousClosePrice(compareToPreviousClosePrice);
   const fluctuationRatioSign = getFluctuationsRatioSign(fluctuationsRatio);
 
   const selectedVariantStyles = variantStyles[variant];

--- a/src/utils/stockPriceUtils.ts
+++ b/src/utils/stockPriceUtils.ts
@@ -1,32 +1,19 @@
 // 이전 종가 대비 가격 변화 색상을 반환 (+ : 빨간색, - : 파란색)
-export const getCompareToPreviousClosePriceColor = (data: number) => {
+export const getTextColor = (data: number) => {
   if (data === 0) return "text-grayscale-500";
   else if (data < 0) return "text-blue-600";
   else return "text-warning-100";
 };
 
-// 이전 종가 대비 가격 변화 화살표 기호를 반환 (+ : ▲, - : ▼)
-export const getCompareToPreviousClosePriceArrow = (data: number) => {
-  if (data === 0) return "";
-  else if (data < 0) return "▼";
-  else return "▲";
+// 숫자 값에 따라 상승 또는 하락 화살표 표시를 포함하여 문자열을 반환
+export const formatValueWithIndicator = (data: number) => {
+  if (data === 0) return 0;
+  else if (data < 0) return `▼${Math.abs(data)}`;
+  else return `▲${data}`;
 };
 
-// 이전 종가 대비 가격 변화를 부호 없이 숫자만 반환
-export const getAbsoluteCompareToPreviousClosePrice = (data: number) => {
-  return Math.abs(data);
-};
-
-// 변동률 색상을 반환 (+ : 빨간색, - : 파란색)
-export const getFluctuationsRatioColor = (data: number) => {
-  if (data === 0) return "text-grayscale-500";
-  else if (data < 0) return "text-blue-600";
-  else return "text-warning-100";
-};
-
-// 변동률 부호를 반환 (+ 일 때만)
-export const getFluctuationsRatioSign = (data: number) => {
-  if (data === 0) return "";
-  else if (data < 0) return "-";
-  else return "+";
+// 숫자 값이 양수일 경우 + 부호를 포함하여 문자열을 반환
+export const formatValueWithSign = (data: number) => {
+  if (data > 0) return `+${data}`;
+  return data;
 };

--- a/src/utils/stockPriceUtils.ts
+++ b/src/utils/stockPriceUtils.ts
@@ -1,11 +1,15 @@
 // 이전 종가 대비 가격 변화 색상을 반환 (+ : 빨간색, - : 파란색)
 export const getCompareToPreviousClosePriceColor = (data: number) => {
-  return data < 0 ? "text-blue-600" : "text-warning-100";
+  if (data === 0) return "text-grayscale-500";
+  else if (data < 0) return "text-blue-600";
+  else return "text-warning-100";
 };
 
 // 이전 종가 대비 가격 변화 화살표 기호를 반환 (+ : ▲, - : ▼)
 export const getCompareToPreviousClosePriceArrow = (data: number) => {
-  return data < 0 ? "▼" : "▲";
+  if (data === 0) return "";
+  else if (data < 0) return "▼";
+  else return "▲";
 };
 
 // 이전 종가 대비 가격 변화를 +, -가 아닌 화살표 기호를 사용하기 때문에 "-" 부호를 없애는 용도
@@ -15,10 +19,14 @@ export const getCompareToPreviousClosePriceSign = (data: number) => {
 
 // 변동률 색상을 반환 (+ : 빨간색, - : 파란색)
 export const getFluctuationsRatioColor = (data: number) => {
-  return data < 0 ? "text-blue-600" : "text-warning-100";
+  if (data === 0) return "text-grayscale-500";
+  else if (data < 0) return "text-blue-600";
+  else return "text-warning-100";
 };
 
 // 변동률 부호를 반환 (+ 일 때만)
 export const getFluctuationsRatioSign = (data: number) => {
-  return data < 0 ? "" : "+";
+  if (data === 0) return "";
+  else if (data < 0) return "-";
+  else return "+";
 };

--- a/src/utils/stockPriceUtils.ts
+++ b/src/utils/stockPriceUtils.ts
@@ -12,9 +12,9 @@ export const getCompareToPreviousClosePriceArrow = (data: number) => {
   else return "▲";
 };
 
-// 이전 종가 대비 가격 변화를 +, -가 아닌 화살표 기호를 사용하기 때문에 "-" 부호를 없애는 용도
-export const getCompareToPreviousClosePriceSign = (data: number) => {
-  return data < 0 ? data * -1 : data;
+// 이전 종가 대비 가격 변화를 부호 없이 숫자만 반환
+export const getAbsoluteCompareToPreviousClosePrice = (data: number) => {
+  return Math.abs(data);
 };
 
 // 변동률 색상을 반환 (+ : 빨간색, - : 파란색)

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,9 @@ const utilsPlugin: PluginCreator = ({ addUtilities }) =>
   });
 
 const config: Config = {
+  purge: {
+    safelist: ["text-grayscale-500", "text-blue-600", "text-warning-100"],
+  },
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -69,7 +72,7 @@ const config: Config = {
           200: "#e9e9e9",
           300: "#c5c5c5",
           400: "#9f9f9f",
-          500: "#7d7d7d",
+          500: "#7D7D7D",
           600: "#575757",
           700: "#454545",
           800: "#282828",


### PR DESCRIPTION
## 📌 기능 설명

<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업
- [x] 헤더 컴포넌트 구현
-->

- [x] 주식 데이터에서 +,-가 아닌 변동이 없을 경우의 처리 추가
- [x] 주식 데이터 관련 stockPriceUtils의 함수들 리팩터링

## 📌 구현 내용

<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다.
-->

### 주식 데이터 중립 처리
- 주식 데이터에서 +,-가 아닌 변동이 없을 경우 구현 (텍스트 컬러 변경, 부호와 화살표 기호 제거)
- 종목 AI 리포트에서 변동이 없을 때는 따로 피그마에 나와있는게 없어서, 화살표 기호를 없애고 텍스트 컬러를 중립일 때의 컬러로 변경해두었습니다.

### 주식 데이터 처리하는 유틸 함수 리팩터링 및 중립 처리 추가
- `getTextColor`함수
   - 텍스트 컬러를 지정하는 함수가 겹치기 때문에 `getTextColor`함수 하나로 통일했습니다.
- `formatValueWithIndicator`함수
   - 화살표기호가 필요한 주식 데이터는 항상 숫자값과 함께 쓰이기 때문에 내부에서 절댓값처리 후 화살표 기호를 함께 붙인 문자열을 반환하도록 리팩터링했습니다.
- `formatValueWithSign`함수
   - 데이터 값이 양수일 경우에는 `+`기호를 별도로 붙여줘야하기 때문에, 내부에서 양수인지 확인 후 `+`기호와 함께 데이터를 반환하도록 리팩터링했습니다.

### tailwindcss 설정에 safelist 추가
`getTextColor`에서 `data===0`일 때 텍스트 컬러는 맞게 반환하지만, 실제 tailwind css로 인식을 할 때도 있고 안될 때도 있는 버그가 있었습니다. 그래서 `className`에는 텍스트컬러가 들어가지만 실제로 `font-color`로 반영되지 않았습니다. 그래서 `safelist`에 `getTextColor`함수에 의해 동적으로 지정되는 색상 3개를 모두 지정했습니다.

## 📌 구현 결과

<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

- 주식데이터가 중립일 때
![image](https://github.com/doksuri5/frontend/assets/55550034/01f216da-ed3d-4f21-bfa4-699ed96113e8)

- +일 때
![image](https://github.com/doksuri5/frontend/assets/55550034/1d454e7e-dc01-46aa-8d58-70d1063552a0)


## 📌 논의하고 싶은 점

<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요?
-->

리팩터링하면서 제 담당이 아닌 홈, 관심주식, 발견 페이지들에도 수정이 생겨서 혹시 이상한 부분이 있는지 확인 부탁드려요! 또 더 좋게 리팩터링하는 방법이 있는지 피드백 부탁드립니다!
tailwindcss 설정에 `safelist` 추가한 것 관련해서 다른 해결 방법이 있을까요? 