### PR TITLE
[QJ5-117] formData에 isAgreeCreditInfo, investPropensity 필드 추가

### DIFF
--- a/src/app/[lang]/(auth)/_components/ProfileSetUpForm.tsx
+++ b/src/app/[lang]/(auth)/_components/ProfileSetUpForm.tsx
@@ -166,7 +166,12 @@ export default function ProfileSetUpForm() {
     if (data.tags) {
       formData.append("reuters_code", JSON.stringify(data.tags.map((item) => item.value)));
     }
+
     formData.append("nickname", data.nickname);
+
+    formData.append("isAgreeCreditInfo", JSON.stringify(data.isAgreeCreditInfo));
+
+    formData.append("investPropensity", JSON.stringify(data.investPropensity));
 
     const additionalData = registerFormData();
 


### PR DESCRIPTION
## 📌 기능 설명

<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업
- [x] 헤더 컴포넌트 구현
-->

## 📌 구현 내용

<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다.
-->

formData에 isAgreeCreditInfo, investPropensity 필드 추가 코드가 누락돼서 다시 추가했습니다!!

## 📌 구현 결과

<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점

<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요?
-->
