### PR TITLE
[QJ5-122] 회원탈퇴 후 메인페이지 이동 시 버그 수정, 메일 인증 초시계 위치 수정

### DIFF
--- a/src/app/[lang]/(auth)/withdraw/page.tsx
+++ b/src/app/[lang]/(auth)/withdraw/page.tsx
@@ -10,7 +10,7 @@ export default function WithdrawPage() {
   const router = useRouter();
 
   const handleLogout = () => {
-    router.push('/home');      
+    router.replace('/home');      
     logoutAction();
   };
 

--- a/src/app/[lang]/(auth)/withdraw/page.tsx
+++ b/src/app/[lang]/(auth)/withdraw/page.tsx
@@ -1,26 +1,29 @@
 "use client";
 
-import Link from "next/link";
 import CommonLayout from "../_components/CommonLayout";
 
 import { Button } from "@/components/common";
 import { logoutAction } from "@/actions/auth-action";
+import { useRouter } from 'next/navigation';
 
 export default function page() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    router.push('/home');      
+    logoutAction();
+  };
+
   return (
-    <>
       <CommonLayout title="회원탈퇴가 완료되었습니다." childrenClass="w-[39.4rem] flex_col_center">
         <p className="body_2 text-center text-grayscale-900">
           아잇나우를 이용해주셔서 감사합니다.
           <br />
           더욱 더 노력하고 발전하는 아잇나우가 되겠습니다.
         </p>
-        <Link href="/" replace>
-          <Button size="lg" className="mt-[5.6rem] w-[36.8rem] text-white" onClick={() => logoutAction()}>
+          <Button size="lg" className="mt-[5.6rem] w-[36.8rem] text-white" onClick={handleLogout}>
             확인
           </Button>
-        </Link>
       </CommonLayout>
-    </>
   );
 }

--- a/src/app/[lang]/(auth)/withdraw/page.tsx
+++ b/src/app/[lang]/(auth)/withdraw/page.tsx
@@ -10,7 +10,7 @@ export default function WithdrawPage() {
   const router = useRouter();
 
   const handleLogout = () => {
-    router.replace('/home');      
+    router.replace('/');      
     logoutAction();
   };
 

--- a/src/app/[lang]/(auth)/withdraw/page.tsx
+++ b/src/app/[lang]/(auth)/withdraw/page.tsx
@@ -4,12 +4,12 @@ import CommonLayout from "../_components/CommonLayout";
 
 import { Button } from "@/components/common";
 import { logoutAction } from "@/actions/auth-action";
-import { useRouter } from 'next/navigation';
+import { useRouter } from "next/navigation";
 
-export default function page() {
+export default function WithdrawPage() {
   const router = useRouter();
 
-  const handleLogout = async () => {
+  const handleLogout = () => {
     router.push('/home');      
     logoutAction();
   };

--- a/src/app/[lang]/(mypage)/mypage/_api/withdrawApi.ts
+++ b/src/app/[lang]/(mypage)/mypage/_api/withdrawApi.ts
@@ -20,6 +20,10 @@ export async function withdraw(formData: IWithdrawForm) {
     });
 
     const data = await response.json();
+
+    if (data.ok) {
+      cookieStore.delete("connect.sid")
+    }
     return data;
   }
 }

--- a/src/app/[lang]/(mypage)/mypage/_components/VerifyModal.tsx
+++ b/src/app/[lang]/(mypage)/mypage/_components/VerifyModal.tsx
@@ -65,7 +65,7 @@ export default function VerifyModal({ isOpen, onClose, onEdit }: TVerifyModalPro
     if (seconds === null) return "";
     const minutes = Math.floor(seconds / 60);
     const remainingSeconds = seconds % 60;
-    return `${minutes}:${remainingSeconds < 10 ? `0${remainingSeconds}` : remainingSeconds}`;
+    return `0${minutes}:${remainingSeconds < 10 ? `0${remainingSeconds}` : remainingSeconds}`;
   };
 
   const handleVerifyPassword = async () => {
@@ -221,10 +221,12 @@ export default function VerifyModal({ isOpen, onClose, onEdit }: TVerifyModalPro
                     onChange={(e) => setCode(e.target.value)}
                     labelName="인증 코드 입력"
                     placeholder="인증 코드를 입력해주세요"
+                    suffix={
+                      <div className="text-[1.4rem] text-blue-500">
+                        {timeLeft !== null && formatTime(timeLeft)}
+                      </div>
+                    }
                   />
-                  <div className="flex justify-end text-[1.4rem] text-blue-500">
-                    {timeLeft !== null && formatTime(timeLeft)}
-                  </div>
                   <Button
                     size="lg"
                     bgColor={code ? "bg-navy-900" : "bg-grayscale-200"}

--- a/src/app/[lang]/(mypage)/mypage/_components/WithdrawModal.tsx
+++ b/src/app/[lang]/(mypage)/mypage/_components/WithdrawModal.tsx
@@ -8,6 +8,7 @@ import useUserStore from "@/stores/useUserStore";
 import useAlert from "@/hooks/use-alert";
 import { passwordCert } from "../_api/privacyApi";
 import { deleteGoogleUserAccount, deleteKakaoUserAccount, deleteNaverUserAccount, withdraw } from "../_api/withdrawApi";
+import useToast from "@/hooks/use-toast";
 
 const withdrawReasons = [
   { value: "inconvenient_service", text: "이용이 불편하고 장애가 많아서" },
@@ -30,6 +31,7 @@ export interface IWithdrawForm {
 export default function WithdrawModal({ isOpen, onClose }: TWithdrawModalProps) {
   const { userStoreData } = useUserStore();
   const { alertInfo, customAlert } = useAlert();
+  const { showLoadingToast, updateToast } = useToast();
   const router = useRouter();
 
   const [password, setPassword] = useState("");
@@ -83,12 +85,12 @@ export default function WithdrawModal({ isOpen, onClose }: TWithdrawModalProps) 
   };
 
   const handleWithdraw = async () => {
-    if (userStoreData?.login_type === "local") {
-      const passwordResponse = await handleVerifyPassword();
-      if (!passwordResponse) return;
-    } else {
+    const loadingToastId = showLoadingToast("회원 탈퇴 처리 중...");
+
+    if (userStoreData?.login_type !== "local"){
       const socialResult = await handleSocialAccountWithdraw(userStoreData!.login_type);
       if (!socialResult) {
+        updateToast(loadingToastId, `${userStoreData!.login_type.toUpperCase()} 로그인 회원 탈퇴 도중 오류 발생`, "error");
         customAlert({
           title: `${userStoreData!.login_type.toUpperCase()} 로그인 회원 탈퇴 도중 오류가 발생했습니다.`,
           subText: "잠시 후 다시 시도해 주세요.",
@@ -97,6 +99,15 @@ export default function WithdrawModal({ isOpen, onClose }: TWithdrawModalProps) 
         return;
       }
     }
+
+    if (userStoreData?.login_type === "local") {
+      const passwordResponse = await handleVerifyPassword();
+      if (!passwordResponse) {
+        updateToast(loadingToastId, "비밀번호 검증 실패", "error");
+        return
+      };
+    }
+    
 
     const formData = {
       email: userStoreData?.email,
@@ -108,6 +119,7 @@ export default function WithdrawModal({ isOpen, onClose }: TWithdrawModalProps) 
       const response = await withdraw(formData);
 
       if (!response.ok) {
+        updateToast(loadingToastId, "회원 탈퇴 처리 중 오류 발생", "error");
         customAlert({
           title: "회원 탈퇴 처리 중 오류가 발생했습니다.",
           subText: "잠시 후 다시 시도해 주세요.",
@@ -116,8 +128,10 @@ export default function WithdrawModal({ isOpen, onClose }: TWithdrawModalProps) 
         return;
       }
 
-      router.push("/withdraw");
+      updateToast(loadingToastId, "회원 탈퇴가 성공적으로 처리되었습니다.", "success");
+      router.push("/withdraw")
     } catch (err) {
+      updateToast(loadingToastId, "회원 탈퇴 처리 중 오류 발생", "error");
       customAlert({
         title: "회원 탈퇴 처리 중 오류가 발생했습니다.",
         subText: err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.",

--- a/src/app/[lang]/(mypage)/mypage/_components/WithdrawModal.tsx
+++ b/src/app/[lang]/(mypage)/mypage/_components/WithdrawModal.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/utils/cn";
 import { Modal, Button, Dropdown, Input, Alert } from "@/components/common";
 import useUserStore from "@/stores/useUserStore";
-import { cn } from "@/utils/cn";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import useAlert from "@/hooks/use-alert";
 import { passwordCert } from "../_api/privacyApi";
 import { deleteGoogleUserAccount, deleteKakaoUserAccount, deleteNaverUserAccount, withdraw } from "../_api/withdrawApi";
-import useAlert from "@/hooks/use-alert";
 
 const withdrawReasons = [
   { value: "inconvenient_service", text: "이용이 불편하고 장애가 많아서" },

--- a/src/app/[lang]/(mypage)/mypage/_components/WithdrawModal.tsx
+++ b/src/app/[lang]/(mypage)/mypage/_components/WithdrawModal.tsx
@@ -129,7 +129,7 @@ export default function WithdrawModal({ isOpen, onClose }: TWithdrawModalProps) 
       }
 
       updateToast(loadingToastId, "회원 탈퇴가 성공적으로 처리되었습니다.", "success");
-      router.push("/withdraw")
+      router.replace("/withdraw")
     } catch (err) {
       updateToast(loadingToastId, "회원 탈퇴 처리 중 오류 발생", "error");
       customAlert({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -62,6 +62,7 @@ export const middleware = async (req: NextRequest) => {
     `/${locale}/find-email`,
     `/${locale}/find-password`,
     `/${locale}/exist`,
+    `/${locale}/withdraw`,
   ]);
 
   // 로그인이 필요한 경로이고 유저가 로그인 하지 않은 경우 로그인 페이지로 넘기기


### PR DESCRIPTION
## 📌 기능 설명

- 회원탈퇴 후 메인페이지 이동 시 제대로 메인페이지가 보이지 않는 버그 수정
- 메일 인증 초시계 위치 수정
- 회원탈퇴 시 로딩 추가

## 📌 구현 내용

- 회원탈퇴 후 메인페이지로 이동할 때 로그인 체크 관련 에러가 발생하는 문제를 수정했습니다.
- 메일 인증 시 초시계의 위치를 입력 필드 내부 오른쪽에 배치시켰습니다.
- 민아님이 구현해주신 토스트를 이용해 회원탈퇴 시 로딩 메시지를 처리했습니다.

## 📌 구현 결과

![회원탈퇴22](https://github.com/user-attachments/assets/459d58da-f39a-4fdf-845f-9e5a53ebd127)

## 📌 논의하고 싶은 점
x