### PR TITLE
[QJ5-123] 발견페이지 검색 엔터키 검색 이슈 

### DIFF
--- a/src/app/[lang]/(discovery)/discovery/_components/DiscoveryInput.tsx
+++ b/src/app/[lang]/(discovery)/discovery/_components/DiscoveryInput.tsx
@@ -31,7 +31,13 @@ const DiscoveryInput = () => {
   };
 
   return (
-    <section className="relative h-[5.6rem] w-full">
+    <form
+      className="relative h-[5.6rem] w-full"
+      onSubmit={(e) => {
+        e.preventDefault();
+        moveLink();
+      }}
+    >
       <SearchIcon className="absolute left-[1.6rem] top-[1.6rem] z-10 cursor-pointer" onClick={moveLink} />
       <Input
         ref={inputRef}
@@ -40,9 +46,8 @@ const DiscoveryInput = () => {
         inputGroupClass="w-full h-[5.6rem]"
         inputClass="text-navy-900 h-[5.6rem] pl-[4.4rem] rounded-[0.8rem]"
         placeholder="종목을 검색해주세요"
-        onKeyUp={(e) => e.key === "Enter" && moveLink()}
       />
-    </section>
+    </form>
   );
 };
 

--- a/src/app/[lang]/(report)/report/_components/index.tsx
+++ b/src/app/[lang]/(report)/report/_components/index.tsx
@@ -30,7 +30,7 @@ export default function Report({ reutersCode }: { reutersCode: TReutersCodes }) 
         <AIAnalystReport reutersCode={reutersCode} />
       </div>
       <Suspense fallback={<PopularNewsSkeleton />}>
-        <PopularNewsComponent popularNewsData={DUMMY_POPULAR_NEWS_ITEMS} />
+        {/* <PopularNewsComponent popularNewsData={DUMMY_POPULAR_NEWS_ITEMS} /> */}
       </Suspense>
     </div>
   );


### PR DESCRIPTION
## 📌 기능 설명

- [x] 발견페이지에서 엔터기로 조회시 데이터 요청이 제대로 되지 않는 이슈 
- [x] 리포트페이지내의 임시 주석처리 

## 📌 구현 내용


https://github.com/user-attachments/assets/c32e04f6-c466-4a3e-a69b-528094bc25c1

검색 영역의 아이콘 클릭시 데이터 통신이 제대로 동작하지만 엔터키 적용시 두번씩 중복으로 이벤트가 발생되면서 제대로 데이터 요청이 되지 않고 있는 것 같아 form 태그로 수정했습니다. 


## 📌 구현 결과


https://github.com/user-attachments/assets/437b0b87-1566-461a-a7a5-f95e41f2756d


## 📌 논의하고 싶은 점

