### PR TITLE
[QJ5-131] 뉴스 페이지에서 발생하는 버그 수정

### DIFF
--- a/src/actions/news.ts
+++ b/src/actions/news.ts
@@ -68,7 +68,6 @@ export const fetchInterestStockNews = async () => {
       if (data.length > 0) {
         let refinedData = (data as any[]).map(({ content_img, title, published_time, publisher, index }) => ({
           image: content_img,
-          // TODO: 시간 포맷팅하기
           date: published_time,
           _id: index,
           title: title.ko,
@@ -143,7 +142,6 @@ export const fetchNewsDetail = async (index: any) => {
 
       let refinedNews = {
         image: news.content_img,
-        // TODO: 시간 포맷팅하기
         publishedTime: news.published_time,
         _id: news.index,
         title: news.title.ko,

--- a/src/app/[lang]/(news)/news/_components/index.tsx
+++ b/src/app/[lang]/(news)/news/_components/index.tsx
@@ -5,6 +5,7 @@ import { Card, CardSkeleton, PopularNews, PopularNewsSkeleton } from "@/componen
 import NewsInfinityList from "@/app/[lang]/(news)/news/_components/NewsInfinityList";
 import { Suspense, useState } from "react";
 import useInfiniteNews from "@/hooks/useInfiniteNews";
+import { getTimeDifference } from "@/utils/getTimeDifference";
 
 export default function News({ popularNews, interestStockNews }: any) {
   const [currentPage, setCurrentPage] = useState(1);
@@ -39,7 +40,7 @@ export default function News({ popularNews, interestStockNews }: any) {
                   _id={news._id}
                   variant="halfMediaCard"
                   style="w-1/3"
-                  date={news.date}
+                  date={`${getTimeDifference(news.date)}`}
                   title={news.title}
                   image={news.image}
                   content={news.description}

--- a/src/app/[lang]/(news)/news/_components/index.tsx
+++ b/src/app/[lang]/(news)/news/_components/index.tsx
@@ -36,6 +36,7 @@ export default function News({ popularNews, interestStockNews }: any) {
               interestStockNews.value.map((news: any) => (
                 <Card
                   key={news._id}
+                  _id={news._id}
                   variant="halfMediaCard"
                   style="w-1/3"
                   date={news.date}

--- a/src/app/[lang]/(news)/news/_components/index.tsx
+++ b/src/app/[lang]/(news)/news/_components/index.tsx
@@ -43,7 +43,7 @@ export default function News({ popularNews, interestStockNews }: any) {
                   title={news.title}
                   image={news.image}
                   content={news.description}
-                  publisher={news.newspaperCompany}
+                  publisher={news.publisher}
                 />
               ))
             ) : (

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -74,7 +74,7 @@ export default function Card({
         <Link href={`${NEWS_PATH}/${_id}`}>
           <div className={cn(`flex min-h-[36rem] min-w-[38.8rem] flex-col overflow-hidden rounded-[1.6rem] ${style}`)}>
             <div className="relative min-h-[23.6rem] w-[100%]">
-              <Image src={image || Rectangle} alt="news-image" className="object-cover" fill />
+              <Image src={image || Rectangle} alt="news-image" className="object-cover" sizes="388px" fill />
             </div>
             <div className="flex w-full flex-col gap-[.8rem] rounded-b-[1.6rem] bg-grayscale-0 px-[2.4rem] py-[1.6rem] font-medium">
               <div className="body_3 line-clamp-2 h-[5.6rem] cursor-pointer text-ellipsis text-grayscale-900">

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -104,6 +104,7 @@ export default function Card({
               <Image
                 fill
                 sizes={`${size === "large" ? "min-h-[42rem]" : "min-h-[20rem]"}`}
+                className="object-cover"
                 src={image || (size === "large" ? LargeRect : SmallRect)}
                 alt="news-image"
               />

--- a/src/components/common/List/NewsItem.tsx
+++ b/src/components/common/List/NewsItem.tsx
@@ -43,7 +43,7 @@ export default function NewsItem({
             `relative h-[10rem] w-[17.2rem] flex-shrink-0 overflow-hidden rounded-2xl ${selectedVariantStyles.imageSize}`,
           )}
         >
-          <Image src={image} fill style={{ objectFit: "cover" }} alt="news-image" />
+          <Image src={image} fill className="object-cover" sizes="252px" alt="news-image" />
         </div>
         <div className="flex w-full flex-1 flex-col gap-[1.6rem]">
           <div className="flex items-center justify-between">

--- a/src/components/common/PoPularNews.tsx
+++ b/src/components/common/PoPularNews.tsx
@@ -1,3 +1,4 @@
+import { getDateWithoutTime } from "@/utils/getDateWithoutTime";
 import Card from "./Card";
 import { CardNewsDataType } from "@/types";
 
@@ -16,7 +17,7 @@ const PopularNews = ({ popularNewsData }: TPopularNewsType) => {
           image={popularNewsData[0]?.image}
           title={popularNewsData[0].title}
           content={popularNewsData[0].description}
-          date={popularNewsData[0].date}
+          date={getDateWithoutTime(popularNewsData[0].date)}
           publisher={popularNewsData[0].publisher}
           style="w-1/2 h-full"
         />
@@ -26,7 +27,7 @@ const PopularNews = ({ popularNewsData }: TPopularNewsType) => {
             image={popularNewsData[1]?.image}
             title={popularNewsData[1].title}
             content={popularNewsData[1].description}
-            date={popularNewsData[1].date}
+            date={getDateWithoutTime(popularNewsData[1].date)}
             publisher={popularNewsData[1].publisher}
             variant="fullMediaCard"
             size="small"
@@ -36,7 +37,7 @@ const PopularNews = ({ popularNewsData }: TPopularNewsType) => {
             image={popularNewsData[2]?.image}
             title={popularNewsData[2].title}
             content={popularNewsData[2].description}
-            date={popularNewsData[2].date}
+            date={getDateWithoutTime(popularNewsData[2].date)}
             publisher={popularNewsData[2].publisher}
             variant="fullMediaCard"
             size="small"


### PR DESCRIPTION
## 📌 기능 설명

<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업
- [x] 헤더 컴포넌트 구현
-->

뉴스페이지에서 발생하는 버그와 카드의 이미지 비율을 수정했습니다!

## 📌 구현 내용

- '관심종목관련뉴스'를 클릭했을 때 오류가 발생하고 뉴스 디테일 페이지로 이동하지 않는 에러 수정
- 뉴스 발행 시간 포맷팅 코드 머지하면서 삭제된 것 다시 추가
- '관심종목관련뉴스' 카드에 발행사 추가
- 관심종목관련뉴스' 카드의 발행시간 포맷팅
- 카드 컴포넌트 이미지 사이즈 변경 (기존: 꽉 차는 것 → 수정 후: 이미지의 비율이 깨지지 않도록)
- 뉴스에 사용되는 이미지 컴포넌트에서 `sizes` 속성 지정하여 경고 콘솔 뜨지 않도록 함
    ![image](https://github.com/user-attachments/assets/0e58c913-4b71-41ef-8065-1805e3d29c27)


## 📌 구현 결과

![image](https://github.com/user-attachments/assets/772ed88b-43eb-4b55-a065-e36ea5fb3184)
![image](https://github.com/user-attachments/assets/c64c0a6a-c03e-414d-8703-5c646bd700aa)
