### PR TITLE
[QJ5-149] 발견, 관심주식 페이지 검색 버그 수정

### DIFF
--- a/src/app/[lang]/(discovery)/discovery/_components/DiscoveryInput.tsx
+++ b/src/app/[lang]/(discovery)/discovery/_components/DiscoveryInput.tsx
@@ -10,7 +10,7 @@ import SearchIcon from "@/public/icons/search_icon.svg?component";
 const DiscoveryInput = () => {
   const searchParams = useSearchParams();
   const initialSearchQuery = searchParams.get("search") || "";
-  const { inputValue, debouncedValue, setInputValue } = useDebouncedSearch(initialSearchQuery);
+  const { inputValue, debouncedValue, setInputValue } = useDebouncedSearch(decodeURIComponent(initialSearchQuery));
   const router = useRouter();
   const pathname = usePathname();
   const [isVisible, setIsVisible] = useState(false);
@@ -27,7 +27,7 @@ const DiscoveryInput = () => {
     }
 
     const newPath = `${pathname}?${params.toString()}`;
-    router.replace(newPath);
+    router.push(newPath);
   };
 
   return (

--- a/src/app/[lang]/(discovery)/discovery/_components/SearchItem.tsx
+++ b/src/app/[lang]/(discovery)/discovery/_components/SearchItem.tsx
@@ -13,7 +13,7 @@ const SearchItem = ({ search, deleteSearch }: { search: SearchTextDataType; dele
 
   const moveLink = (search: string) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set("search", search);
+    params.set("search", encodeURIComponent(search));
 
     const newPath = `${pathname}?${params.toString()}`;
     router.push(newPath);
@@ -31,7 +31,7 @@ const SearchItem = ({ search, deleteSearch }: { search: SearchTextDataType; dele
         </span>
       </div>
       <div className="flex_row gap-[.8rem]">
-        <span className="body_5 text-grayscale-400">{search.searchDate.split("T")[0].slice(5)}</span>
+        <span className="body_5 text-grayscale-400">{search.searchDate.split("T")[0].slice(5).replace("-", ".")}</span>
         <button type="button" onClick={deleteSearch}>
           <CloseIcon />
         </button>

--- a/src/app/[lang]/(home)/home/news.tsx
+++ b/src/app/[lang]/(home)/home/news.tsx
@@ -24,7 +24,7 @@ const News = ({ popularNews, interestNews }: { popularNews: any; interestNews: a
       <h2 className="heading_4 pb-[2.4rem] font-bold">{session.data?.user.name ?? "김스팩"}님을 위한 주식 뉴스</h2>
       <div className="flex flex-col rounded-[1.6rem] bg-white p-[4.8rem]">
         <p className="body_1 pb-[1.6rem]">관심종목</p>
-        <ul className="flex gap-[2rem] overflow-x-scroll scrollbar-hide" ref={ref} {...draggableOptions()}>
+        <ul className="flex touch-none gap-[2rem] overflow-x-scroll scrollbar-hide" ref={ref} {...draggableOptions()}>
           {interestNews.map((item: any) => (
             <Card key={item.id} variant="iconCard" date={item.date} title={item.title} />
           ))}

--- a/src/app/[lang]/(mystock)/mystock/_components/MyStockRecentSearches.tsx
+++ b/src/app/[lang]/(mystock)/mystock/_components/MyStockRecentSearches.tsx
@@ -47,7 +47,7 @@ const MyStockRecentSearches = ({ setSearchText }: TMyStockRecentSearchedProps) =
           전체삭제
         </span>
       </div>
-      <ul className="flex gap-[2rem] overflow-x-scroll scrollbar-hide" ref={ref} {...draggableOptions()}>
+      <ul className="flex touch-none gap-[2rem] overflow-x-scroll scrollbar-hide" ref={ref} {...draggableOptions()}>
         {stockItemList.map((stock) => (
           <div
             key={stock.id}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -100,7 +100,7 @@ export default function Modal({
                     alt="close"
                     width={48}
                     height={48}
-                    className="cursor-pointer"
+                    className="h-[4.8rem] w-[4.8rem] cursor-pointer"
                     onClick={onClose}
                   />
                 )}

--- a/src/components/common/SearchBox.tsx
+++ b/src/components/common/SearchBox.tsx
@@ -81,7 +81,9 @@ const SearchBox = ({ inputValue, onSelect }: TSearchBox) => {
           </ul>
         ) : (
           <div className="flex flex-col gap-[1rem] text-navy-700">
-            <h3 className="body_3 font-bold">&quot;{inputValue}&quot; 검색 결과가 없습니다.</h3>
+            <h3 className="body_3 flex gap-[.8rem] font-bold">
+              &quot;<span className="block max-w-[35rem] truncate">{inputValue}</span>&quot; 검색 결과가 없습니다.
+            </h3>
             <p className="body_5">단어의 철자가 정확한지 확인해 주세요.</p>
           </div>
         )}


### PR DESCRIPTION
## 📌 기능 설명

- [x] 검색 창 버그 수정
- [x] 터치 드래그 경고 수정
- [x] 모달 종료 버튼 종횡비 경고 수정  

## 📌 구현 내용

검색 하고 다른 페이지 이동한 후 다시 검색 창으로 돌아오면 검색 창에 인코딩 된 값이 들어가는 버그 수정

## 📌 구현 결과

#### 검색 창 버그
![image](https://github.com/user-attachments/assets/796a23c2-2c76-4228-8be9-a1d5fb93c492)

#### 터치 드래그 경고
<img width="1423" alt="스크린샷 2024-07-23 오전 1 27 58" src="https://github.com/user-attachments/assets/ff348489-37aa-4159-84bf-73909ab244ff">

#### 검색 박스 길이 초과
![image](https://github.com/user-attachments/assets/f2319454-1550-4ef1-bac9-5bcdfd6105ea)

## 📌 논의하고 싶은 점
