### PR TITLE
[QJ5-160] 투자성향데이터 에러 수정

### DIFF
--- a/src/app/[lang]/(auth)/_components/ProfileSetUpForm.tsx
+++ b/src/app/[lang]/(auth)/_components/ProfileSetUpForm.tsx
@@ -26,6 +26,7 @@ import { TProfileSchema, profileSchema } from "@/types/AuthType";
 import { REGISTER_COMPLETE_PATH, REGISTER_PATH } from "@/routes/path";
 
 import EditIcon from "@/public/icons/avatar_edit.svg?component";
+import { TInvestPropensityDetails } from "@/types/investPropensityType";
 
 type TOption = {
   value: string;
@@ -108,7 +109,7 @@ export default function ProfileSetUpForm() {
   };
 
   // InvestPropensity폼에서 넘어온 데이터 처리
-  const handleFormSubmit = (data: any) => {
+  const handleFormSubmit = (data: TInvestPropensityDetails) => {
     setIsOpenOfInvestPropensity(false);
     setValue("investPropensity", data);
     setValue("isAgreeCreditInfo", true);

--- a/src/app/[lang]/(mypage)/mypage/page.tsx
+++ b/src/app/[lang]/(mypage)/mypage/page.tsx
@@ -23,12 +23,16 @@ const fetchUserData = async () => {
     ).json();
 
     if (response.ok) {
-      const userData = response.data;
+      // invest_propensity를 파싱해서 반환
+      let { invest_propensity } = response.data.user_propensity;
 
-      // invest_propensity를 파싱
-      if (userData.user_propensity && typeof userData.user_propensity.invest_propensity === "string") {
-        userData.user_propensity.invest_propensity = JSON.parse(userData.user_propensity.invest_propensity);
-      }
+      // 투자성향데이터를 등록하지 않아서 undefined로 넘어올 경우
+      if (invest_propensity === "undefined") invest_propensity = { 1: "", 2: "", 3: "", 4: "", 5: [] };
+      // 투자성향데이터가 있을 경우
+      else invest_propensity = JSON.parse(invest_propensity);
+
+      response.data.user_propensity.invest_propensity = invest_propensity;
+
       return response.data;
     }
   } catch (err) {

--- a/src/components/common/InvestPropensity.tsx
+++ b/src/components/common/InvestPropensity.tsx
@@ -9,7 +9,7 @@ import { InvestPropensityQuestions } from "@/data/InvestPropensityQuestions";
 import { TInvestPropensityDetails } from "@/types/investPropensityType";
 
 type TInvestPropensityProps = {
-  onSubmit: (data: TInvestPropensityDetails) => Promise<void>;
+  onSubmit: (data: TInvestPropensityDetails) => Promise<void> | void;
   initialData?: {
     investPropensity: {
       1: string;


### PR DESCRIPTION
## 📌 구현 내용

<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다.
-->

마이페이지에서 데이터를 받아올 때 투자성향데이터가 기존 유저는 동의하지 않은 경우, `undefined`로 들어갔기 때문에 이 부분 따로 처리해주었습니다. (새로 가입하는 유저는 `undefined`로 들어가지 않도록 처리해두었습니다!)
프로필설정페이지에서 사용하는 투자성향 폼 `submit`함수는 반환값이 void라서 타입 추가해주었습니다!

## 📌 구현 결과

<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점

<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요?
-->
