### PR TITLE
[QJ5-144] 뉴스 다국어 작업

### DIFF
--- a/src/actions/news.ts
+++ b/src/actions/news.ts
@@ -1,10 +1,10 @@
 "use server";
 
 import { publicFetchApi } from "@/lib/public-api";
-import { z } from "zod";
 import { truncateBackstring } from "@/utils/truncateBackstring";
 import { cookies } from "next/headers";
-import { NewsDataType, SearchStockNewsSchema, SearchStockNewsDataType } from "@/types/NewsDataType2";
+import { SearchStockNewsSchema, SearchStockNewsDataType } from "@/types/NewsDataType2";
+import { auth } from "@/auth";
 
 export const getSearchNews = publicFetchApi.get({
   endpoint: "/news/getSearchNews",
@@ -14,6 +14,7 @@ export const getSearchNews = publicFetchApi.get({
 export const fetchPopularNews = async () => {
   const cookieStore = cookies();
   const connectCookie = cookieStore.get("connect.sid")?.value;
+  const session = await auth();
 
   try {
     const response = await (
@@ -34,9 +35,9 @@ export const fetchPopularNews = async () => {
           image: content_img,
           date: published_time,
           _id: index,
-          title: title.ko,
-          description: description.ko,
-          publisher: publisher.ko,
+          title: title[session?.user.language ?? "ko"],
+          description: description[session?.user.language ?? "ko"],
+          publisher: publisher[session?.user.language ?? "ko"],
         }),
       );
       return refinedData;
@@ -49,6 +50,7 @@ export const fetchPopularNews = async () => {
 export const fetchInterestStockNews = async () => {
   const cookieStore = cookies();
   const connectCookie = cookieStore.get("connect.sid")?.value;
+  const session = await auth();
 
   try {
     const response = await (
@@ -70,8 +72,8 @@ export const fetchInterestStockNews = async () => {
           image: content_img,
           date: published_time,
           _id: index,
-          title: title.ko,
-          publisher: publisher.ko,
+          title: title[session?.user.language ?? "ko"],
+          publisher: publisher[session?.user.language ?? "ko"],
         }));
 
         return [refinedData[0], refinedData[1], refinedData[2]];
@@ -85,6 +87,7 @@ export const fetchInterestStockNews = async () => {
 export const fetchRecentNews = async (pageParam = 1) => {
   const cookieStore = cookies();
   const connectCookie = cookieStore.get("connect.sid")?.value;
+  const session = await auth();
 
   try {
     const response = await (
@@ -106,9 +109,9 @@ export const fetchRecentNews = async (pageParam = 1) => {
           image: content_img,
           publishedTime: published_time,
           _id: index,
-          title: title.ko,
-          publisher: publisher.ko,
-          description: content.ko,
+          title: title[session?.user.language ?? "ko"],
+          publisher: publisher[session?.user.language ?? "ko"],
+          description: content[session?.user.language ?? "ko"],
         }),
       );
 
@@ -122,6 +125,7 @@ export const fetchRecentNews = async (pageParam = 1) => {
 export const fetchNewsDetail = async (index: any) => {
   const cookieStore = cookies();
   const connectCookie = cookieStore.get("connect.sid")?.value;
+  const session = await auth();
 
   try {
     const response = await (
@@ -144,18 +148,18 @@ export const fetchNewsDetail = async (index: any) => {
         image: news.content_img,
         publishedTime: news.published_time,
         _id: news.index,
-        title: news.title.ko,
-        description: truncateBackstring(news.content.ko),
-        publisher: news.publisher.ko,
+        title: news.title[session?.user.language ?? "ko"],
+        description: truncateBackstring(news.content[session?.user.language ?? "ko"]),
+        publisher: news.publisher[session?.user.language ?? "ko"],
         view: news.view,
       };
 
       // 관련 뉴스 필드 정제
       let refinedRelatedNews = (relatedNews as any[]).map(({ index, publisher, published_time, title }) => ({
         _id: index,
-        title: title.ko,
+        title: title[session?.user.language ?? "ko"],
         publishedTime: published_time,
-        newspaperCompany: publisher.ko,
+        newspaperCompany: publisher[session?.user.language ?? "ko"],
       }));
 
       // 관련 주식 필드 정제

--- a/src/app/[lang]/(news)/news/[newsId]/_components/RelatedNews.tsx
+++ b/src/app/[lang]/(news)/news/[newsId]/_components/RelatedNews.tsx
@@ -2,13 +2,18 @@
 
 import { FindNews, FindNewsSkeleton } from "@/components/common";
 import { TIFindNewsProps } from "@/components/common/List/FindNews";
+import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Fragment, useEffect, useState } from "react";
 
 export default function RelatedNews({ relatedNews }: any) {
   const [newsData, setNewsData] = useState<TIFindNewsProps[]>([]);
   const [loading, setLoading] = useState(true);
+
   const t = useTranslations();
+  
+  const { data: session } = useSession();
+  const language = session?.user.language || "ko";
 
   useEffect(() => {
     setNewsData(relatedNews);
@@ -38,7 +43,7 @@ export default function RelatedNews({ relatedNews }: any) {
               publishedTime={news.publishedTime}
               newspaperCompany={news.newspaperCompany}
               style={news?.style}
-              lang={"ko"}
+              lang={language}
             />
             {idx < newsData.length - 1 && <hr className="mb-[1.6rem] mt-[1.8rem]" />}
           </Fragment>

--- a/src/app/[lang]/(news)/news/_components/NewsInfinityList.tsx
+++ b/src/app/[lang]/(news)/news/_components/NewsInfinityList.tsx
@@ -1,11 +1,10 @@
 import NewsItem from "@/components/common/List/NewsItem";
 import NewsItemSkeleton from "@/components/common/skeleton/NewsItemSkeleton";
-import { NewsItemType } from "@/types";
 import { cn } from "@/utils/cn";
 import { Fragment, useEffect, useRef } from "react";
 
 type TINewsListProps = {
-  newsItems: any; //NewsItemType[] | undefined;
+  newsItems: any;
   lineClamp?: "lineClamp-2" | "lineClamp-4";
   variant?: "border" | "noBorder";
   style?: string;

--- a/src/components/common/List/NewsItem.tsx
+++ b/src/components/common/List/NewsItem.tsx
@@ -4,6 +4,7 @@ import { NEWS_PATH } from "@/routes/path";
 import { NewsItemType } from "@/types";
 import { cn } from "@/utils/cn";
 import { getTimeDifference } from "@/utils/getTimeDifference";
+import { useSession } from "next-auth/react";
 
 export type TNewsItemProps = NewsItemType & {
   variant?: "lineClamp-2" | "lineClamp-4";
@@ -34,6 +35,8 @@ export default function NewsItem({
   style,
 }: TNewsItemProps) {
   const selectedVariantStyles = variantStyles[variant];
+  const { data: session } = useSession();
+  const language = session?.user.language || "ko";
 
   return (
     <Link href={`${NEWS_PATH}/${_id}`}>
@@ -49,7 +52,7 @@ export default function NewsItem({
           <div className="flex items-center justify-between">
             <h3 className="body_3 font-bold text-grayscale-900">{title}</h3>
             <div className="body_5 flex gap-[0.8rem] font-medium text-grayscale-600">
-              <span>{getTimeDifference(publishedTime, "ko")}</span>
+              <span>{getTimeDifference(publishedTime, language ?? "ko")}</span>
               <span>∙</span>
               <span>{publisher}</span>
             </div>

--- a/src/components/common/List/StockItem.tsx
+++ b/src/components/common/List/StockItem.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import Link from "next/link";
 import React from "react";
 import StockPrice from "../StockPrice";
+import { useTranslations } from "next-intl";
 
 type TIStockItemProps = StockDataType & {
   iconSize?: number;
@@ -37,6 +38,8 @@ const variantStyles = {
 };
 
 function StockItem({ iconSize = 50, style, variant = "stock", clickNone = false, ...props }: TIStockItemProps) {
+  const t = useTranslations();
+
   const { stockName, symbolCode, reutersCode } = props;
 
   const selectedVariantStyles = variantStyles[variant];
@@ -58,7 +61,11 @@ function StockItem({ iconSize = 50, style, variant = "stock", clickNone = false,
             />
           </div>
           <div>
-            <h3 className={selectedVariantStyles.stockKorName}>{stockName}</h3>
+            <h3 className={selectedVariantStyles.stockKorName}>
+              {t(`stocks.stock${symbolCode}`, {
+                defaultMessage: `${stockName}`,
+              })}
+            </h3>
             <h3 className={selectedVariantStyles.stockEngName}>{symbolCode}</h3>
           </div>
         </div>

--- a/src/dictionaries/ch.json
+++ b/src/dictionaries/ch.json
@@ -225,12 +225,12 @@
     }
   },
   "stocks": {
-    "stockApple": "苹果",
-    "stockMicroSoft": "微软",
-    "stockAmazon": "亚马逊",
-    "stockUnity": "Unity",
-    "stockGoogle": "谷歌",
-    "stockTesla": "特斯拉"
+    "stockAAPL": "苹果",
+    "stockMSFT": "微软",
+    "stockAMZN": "亚马逊",
+    "stockGOOGL": "谷歌",
+    "stockU": "Unity",
+    "stockTSLA": "特斯拉"
   },
   "news": {
     "todaysPopularNews": "今日热门新闻",

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -225,12 +225,12 @@
     }
   },
   "stocks": {
-    "stockApple": "Apple",
-    "stockMicroSoft": "Microsoft",
-    "stockAmazon": "Amazon",
-    "stockUnity": "Unity",
-    "stockGoogle": "Google",
-    "stockTesla": "Tesla"
+    "stockAAPL": "Apple",
+    "stockMSFT": "Microsoft",
+    "stockAMZN": "Amazon",
+    "stockGOOGL": "Google",
+    "stockU": "Unity",
+    "stockTSLA": "Tesla"
   },
   "news": {
     "todaysPopularNews": "Today's Popular News",

--- a/src/dictionaries/fr.json
+++ b/src/dictionaries/fr.json
@@ -225,12 +225,12 @@
     }
   },
   "stocks": {
-    "stockApple": "Apple",
-    "stockMicroSoft": "Microsoft",
-    "stockAmazon": "Amazon",
-    "stockUnity": "Unity",
-    "stockGoogle": "Google",
-    "stockTesla": "Tesla"
+    "stockAAPL": "Apple",
+    "stockMSFT": "Microsoft",
+    "stockAMZN": "Amazon",
+    "stockU": "Unity",
+    "stockGOOGL": "Google",
+    "stockTSLA": "Tesla"
   },
   "news": {
     "todaysPopularNews": "Actualités populaires d'aujourd'hui",

--- a/src/dictionaries/jp.json
+++ b/src/dictionaries/jp.json
@@ -225,12 +225,12 @@
     }
   },
   "stocks": {
-    "stockApple": "アップル",
-    "stockMicroSoft": "マイクロソフト",
-    "stockAmazon": "アマゾン",
-    "stockUnity": "ユニティ",
-    "stockGoogle": "グーグル",
-    "stockTesla": "テスラ"
+    "stockAAPL": "アップル",
+    "stockMSFT": "マイクロソフト",
+    "stockAMZN": "アマゾン",
+    "stockGOOGL": "グーグル",
+    "stockU": "ユニティ",
+    "stockTSLA": "テスラ"
   },
   "news": {
     "todaysPopularNews": "今日の人気ニュース",

--- a/src/dictionaries/ko.json
+++ b/src/dictionaries/ko.json
@@ -225,12 +225,12 @@
     }
   },
   "stocks": {
-    "stockApple": "애플",
-    "stockMicroSoft": "마이크로소프트",
-    "stockAmazon": "아마존",
-    "stockUnity": "유니티",
-    "stockGoogle": "구글",
-    "stockTesla": "테슬라"
+    "stockAAPL": "애플",
+    "stockMSFT": "마이크로소프트",
+    "stockAMZN": "아마존",
+    "stockGOOGL": "구글",
+    "stockU": "유니티",
+    "stockTSLA": "테슬라"
   },
   "news": {
     "todaysPopularNews": "오늘 인기있는 뉴스",

--- a/src/hooks/useInfiniteNews.ts
+++ b/src/hooks/useInfiniteNews.ts
@@ -1,9 +1,13 @@
 import { fetchRecentNews } from "@/actions/news";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
 
 const useInfiniteNews = () => {
+  const { data: session } = useSession();
+  const language = session?.user.language || "ko";
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } = useInfiniteQuery({
-    queryKey: ["news"],
+    queryKey: ["news", language],
     queryFn: ({ pageParam }) => fetchRecentNews(pageParam),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => {


### PR DESCRIPTION
## 📌 기능 설명

<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업
- [x] 헤더 컴포넌트 구현
-->

뉴스페이지, 뉴스상세페이지 다국어 작업 완료

## 📌 구현 내용

<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

설정 언어에 따라 뉴스 api값을 반환하도록 설정해줬습니다!
(예솔님이 대부분 작업해주셨습니다!!👍🏻👍🏻)

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다.
-->

## 📌 구현 결과

<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

https://github.com/user-attachments/assets/31a81313-3509-4fdf-ad1f-860fed7e2d9a

## 📌 논의하고 싶은 점

<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요?
-->
