### PR TITLE
[QJ5-169] 마이페이지 메타 태그 추가

### DIFF
--- a/src/app/[lang]/(auth)/withdraw/page.tsx
+++ b/src/app/[lang]/(auth)/withdraw/page.tsx
@@ -20,10 +20,8 @@ export default function WithdrawPage() {
   return (
     <CommonLayout childrenClass="w-[39.4rem] flex_col_center">
       <CommonTitle title={t("withdraw.withdrawComplete", { defaultMessage: "회원탈퇴가 완료되었습니다." })} />
-      <p className="body_2 text-center text-grayscale-900">
-        {t('withdraw.thankYouPartOne')}
-        <br />
-        {t('withdraw.thankYouPartTwo')}
+      <p className="body_2 text-center text-grayscale-900 whitespace-pre-wrap">
+        {t('withdraw.thankYouMessage')}
       </p>
       <Button size="lg" className="mt-[5.6rem] w-[36.8rem] text-white" onClick={handleLogout}>
         {t("button.confirm")}

--- a/src/app/[lang]/(mypage)/mypage/layout.tsx
+++ b/src/app/[lang]/(mypage)/mypage/layout.tsx
@@ -1,18 +1,21 @@
 import { Suspense, lazy } from "react";
 import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 
 export async function generateMetadata() {
+  const t = await getTranslations("mypage.metadata");
+
   return {
-    title: "마이페이지",
-    description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요.",
-    keywords: "마이페이지, 언어 설정, 개인정보 수정, 개인정보, 프로필, 회원탈퇴, 탈퇴, 이용약관, 약관",
+    title: t("title"),
+    description: t("description"),
+    keywords: t("keywords"),
     openGraph: {
-      title: '마이페이지',
-      description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
+      title: t("openGraph.title"),
+      description: t("openGraph.description"),
     },
     twitter: {
-      title: "마이페이지",
-      description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
+      title: t("twitter.title"),
+      description: t("twitter.description"),
     }
   }
 }

--- a/src/app/[lang]/(mypage)/mypage/layout.tsx
+++ b/src/app/[lang]/(mypage)/mypage/layout.tsx
@@ -1,5 +1,34 @@
+import Head from 'next/head';
 import { Suspense, lazy } from "react";
 import { useTranslations } from "next-intl";
+
+interface IMetadata {
+  title: string;
+  description: string;
+  keywords: string;
+  openGraph: {
+    title: string;
+    description: string;
+  };
+  twitter: {
+    title: string;
+    description: string;
+  };
+}
+
+export const metadata: IMetadata = {
+  title: "마이페이지",
+  description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요.",
+  keywords: "마이페이지, 언어 설정, 개인정보 수정, 개인정보, 프로필, 회원탈퇴, 탈퇴, 이용약관, 약관",
+  openGraph: {
+    title: '마이페이지',
+    description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
+  },
+  twitter: {
+    title: "마이페이지",
+    description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
+  }
+}
 
 const Navigation = lazy(() => import("./_components/Navigation"));
 
@@ -8,6 +37,16 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
   return (
     <>
+      <Head>
+        <title>{metadata.title}</title>
+        <meta name="description" content={metadata.description} />
+        <meta name="keywords" content={metadata.keywords} />
+        <meta property="og:title" content={metadata.openGraph.title} />
+        <meta property="og:description" content={metadata.openGraph.description} />
+        <meta property="twitter:title" content={metadata.twitter.title} />
+        <meta property="twitter:description" content={metadata.twitter.description} />
+      </Head>
+
       <header className="heading_4 pb-[2rem] pt-[5.6rem] font-bold text-gray-900">{t("myPage")}</header>
       <div className="flex flex-row gap-[2.7rem] pb-[11.2rem]">
         <aside className="min-h-[72rem] min-w-[28.5rem] rounded-[1.6rem] bg-grayscale-0">

--- a/src/app/[lang]/(mypage)/mypage/layout.tsx
+++ b/src/app/[lang]/(mypage)/mypage/layout.tsx
@@ -1,32 +1,19 @@
-import Head from 'next/head';
 import { Suspense, lazy } from "react";
 import { useTranslations } from "next-intl";
 
-interface IMetadata {
-  title: string;
-  description: string;
-  keywords: string;
-  openGraph: {
-    title: string;
-    description: string;
-  };
-  twitter: {
-    title: string;
-    description: string;
-  };
-}
-
-export const metadata: IMetadata = {
-  title: "마이페이지",
-  description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요.",
-  keywords: "마이페이지, 언어 설정, 개인정보 수정, 개인정보, 프로필, 회원탈퇴, 탈퇴, 이용약관, 약관",
-  openGraph: {
-    title: '마이페이지',
-    description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
-  },
-  twitter: {
+export async function generateMetadata() {
+  return {
     title: "마이페이지",
-    description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
+    description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요.",
+    keywords: "마이페이지, 언어 설정, 개인정보 수정, 개인정보, 프로필, 회원탈퇴, 탈퇴, 이용약관, 약관",
+    openGraph: {
+      title: '마이페이지',
+      description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
+    },
+    twitter: {
+      title: "마이페이지",
+      description: "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
+    }
   }
 }
 
@@ -37,17 +24,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
   return (
     <>
-      <Head>
-        <title>{metadata.title}</title>
-        <meta name="description" content={metadata.description} />
-        <meta name="keywords" content={metadata.keywords} />
-        <meta property="og:title" content={metadata.openGraph.title} />
-        <meta property="og:description" content={metadata.openGraph.description} />
-        <meta property="twitter:title" content={metadata.twitter.title} />
-        <meta property="twitter:description" content={metadata.twitter.description} />
-      </Head>
-
-      <header className="heading_4 pb-[2rem] pt-[5.6rem] font-bold text-gray-900">{t("myPage")}</header>
+      <header className="heading_4 pb-[2rem] pt-[5.6rem] font-bold text-gray-900">{t("myPage", { defaultMessage: "마이페이지" })}</header>
       <div className="flex flex-row gap-[2.7rem] pb-[11.2rem]">
         <aside className="min-h-[72rem] min-w-[28.5rem] rounded-[1.6rem] bg-grayscale-0">
           <Suspense fallback={<div>Loading...</div>}>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -15,107 +15,6 @@ import { NextIntlClientProvider } from "next-intl";
 
 import AuthSession from "@/providers/AuthSession";
 import { getMessages, unstable_setRequestLocale } from "next-intl/server";
-import Head from "next/head";
-
-export interface IRootMetadata {
-  title: {
-    template: string;
-    default: string;
-  };
-  description: string;
-  keywords: string;
-  authors: {
-    name: string;
-    url: string;
-  }[];
-  robots: {
-    index: boolean;
-    follow: boolean;
-  };
-  metadataBase: URL;
-  openGraph: {
-    title: {
-      template: string;
-      default: string;
-    };
-    description: string;
-    url: string | undefined;
-    siteName: string;
-    type: string;
-    locale: string;
-    images: {
-      url: string;
-      alt: string;
-    }[];
-  };
-  twitter: {
-    card: string;
-    title: {
-      template: string;
-      default: string;
-    };
-    description: string;
-    images: {
-      url: string;
-      alt: string;
-    }[];
-  };
-}
-
-
-export const metadata: IRootMetadata = {
-  title: {
-    template: '%s | 아잇나우',
-    default: 'AI기반 주식 분석 플랫폼 | 아잇나우',
-  },
-  description:
-    '실시간 미국 기업 공시 정보와 데일리 뉴스 데이터 분석 자료를 결합하여, 다양한 국가 언어로 전 세계 사용자를 위해 맞춤화된 실시간 기업 분석 리포트를 제공하는 차세대 AI 애널리스트 플랫폼',
-  keywords:
-    '증권, 주식, 분석, 주식분석, 주식 분석, AI, ai, 아잇나우, aightnow, AIGHTNOW, 해외주식, 해외 주식, 뉴스, 증권 뉴스',
-  authors: [
-    { name: '독수리오형제', url: 'https://github.com/doksuri5/frontend' },
-  ],
-  robots: {
-    index: true,
-    follow: true,
-  },
-  metadataBase: new URL(`${process.env.NEXT_PUBLIC_API_BASE_URL}`),
-  openGraph: {
-    title: {
-      template: '%s | 아잇나우',
-      default: 'AI기반 주식 분석 플랫폼 | 아잇나우',
-    },
-    description:
-      '실시간 기업 분석 리포트를 제공하는 차세대 AI 애널리스트 플랫폼',
-    url: process.env.NEXT_PUBLIC_API_BASE_URL,
-    siteName: '아잇나우',
-    type: 'website',
-    locale: 'ko',
-    images: [
-      {
-        url: '/opengraph-image.png',
-        alt: '아잇나우 로고',
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: {
-      template: '%s | 아잇나우',
-      default: 'AI기반 주식 분석 플랫폼 | 아잇나우',
-    },
-    description:
-      '실시간 기업 분석 리포트를 제공하는 차세대 AI 애널리스트 플랫폼',
-    images: [
-      {
-        url: '/opengraph-image.png',
-        alt: '아잇나우 로고',
-      },
-    ],
-  },
-};
-
-
 
 export async function generateStaticParams() {
   return i18n.locales.map((locale) => ({ lang: locale }));
@@ -137,28 +36,6 @@ export default async function RootLayout({
 
   return (
     <html lang={params.lang} className={pretendard.className}>
-      <Head>
-        <title>{metadata.title.default}</title>
-        <meta name="description" content={metadata.description} />
-        <meta name="keywords" content={metadata.keywords} />
-        <meta name="author" content={metadata.authors.map(author => author.name).join(', ')} />
-        <meta name="robots" content="index, follow" />
-        <meta property="og:title" content={metadata.openGraph.title.default} />
-        <meta property="og:description" content={metadata.openGraph.description} />
-        <meta property="og:url" content={metadata.metadataBase.href} />
-        <meta property="og:type" content={metadata.openGraph.type} />
-        <meta property="og:locale" content={metadata.openGraph.locale} />
-        <meta property="og:site_name" content={metadata.openGraph.siteName} />
-        <meta property="og:image" content={`${metadata.metadataBase.href}${metadata.openGraph.images[0].url}`} />
-        <meta property="og:image:alt" content={metadata.openGraph.images[0].alt} />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={metadata.twitter.title.default} />
-        <meta name="twitter:description" content={metadata.twitter.description} />
-        <meta name="twitter:image" content={`${metadata.metadataBase.href}${metadata.twitter.images[0].url}`} />
-        <meta name="twitter:image:alt" content={metadata.twitter.images[0].alt} />
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/react-toastify/dist/ReactToastify.min.css" />
-        <link rel="stylesheet" href="../globals.css" />
-      </Head>
       <body>
         <NextIntlClientProvider messages={messages}>
           <AuthSession>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -15,6 +15,107 @@ import { NextIntlClientProvider } from "next-intl";
 
 import AuthSession from "@/providers/AuthSession";
 import { getMessages, unstable_setRequestLocale } from "next-intl/server";
+import Head from "next/head";
+
+export interface IRootMetadata {
+  title: {
+    template: string;
+    default: string;
+  };
+  description: string;
+  keywords: string;
+  authors: {
+    name: string;
+    url: string;
+  }[];
+  robots: {
+    index: boolean;
+    follow: boolean;
+  };
+  metadataBase: URL;
+  openGraph: {
+    title: {
+      template: string;
+      default: string;
+    };
+    description: string;
+    url: string | undefined;
+    siteName: string;
+    type: string;
+    locale: string;
+    images: {
+      url: string;
+      alt: string;
+    }[];
+  };
+  twitter: {
+    card: string;
+    title: {
+      template: string;
+      default: string;
+    };
+    description: string;
+    images: {
+      url: string;
+      alt: string;
+    }[];
+  };
+}
+
+
+export const metadata: IRootMetadata = {
+  title: {
+    template: '%s | 아잇나우',
+    default: 'AI기반 주식 분석 플랫폼 | 아잇나우',
+  },
+  description:
+    '실시간 미국 기업 공시 정보와 데일리 뉴스 데이터 분석 자료를 결합하여, 다양한 국가 언어로 전 세계 사용자를 위해 맞춤화된 실시간 기업 분석 리포트를 제공하는 차세대 AI 애널리스트 플랫폼',
+  keywords:
+    '증권, 주식, 분석, 주식분석, 주식 분석, AI, ai, 아잇나우, aightnow, AIGHTNOW, 해외주식, 해외 주식, 뉴스, 증권 뉴스',
+  authors: [
+    { name: '독수리오형제', url: 'https://github.com/doksuri5/frontend' },
+  ],
+  robots: {
+    index: true,
+    follow: true,
+  },
+  metadataBase: new URL(`${process.env.NEXT_PUBLIC_API_BASE_URL}`),
+  openGraph: {
+    title: {
+      template: '%s | 아잇나우',
+      default: 'AI기반 주식 분석 플랫폼 | 아잇나우',
+    },
+    description:
+      '실시간 기업 분석 리포트를 제공하는 차세대 AI 애널리스트 플랫폼',
+    url: process.env.NEXT_PUBLIC_API_BASE_URL,
+    siteName: '아잇나우',
+    type: 'website',
+    locale: 'ko',
+    images: [
+      {
+        url: '/opengraph-image.png',
+        alt: '아잇나우 로고',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: {
+      template: '%s | 아잇나우',
+      default: 'AI기반 주식 분석 플랫폼 | 아잇나우',
+    },
+    description:
+      '실시간 기업 분석 리포트를 제공하는 차세대 AI 애널리스트 플랫폼',
+    images: [
+      {
+        url: '/opengraph-image.png',
+        alt: '아잇나우 로고',
+      },
+    ],
+  },
+};
+
+
 
 export async function generateStaticParams() {
   return i18n.locales.map((locale) => ({ lang: locale }));
@@ -36,6 +137,28 @@ export default async function RootLayout({
 
   return (
     <html lang={params.lang} className={pretendard.className}>
+      <Head>
+        <title>{metadata.title.default}</title>
+        <meta name="description" content={metadata.description} />
+        <meta name="keywords" content={metadata.keywords} />
+        <meta name="author" content={metadata.authors.map(author => author.name).join(', ')} />
+        <meta name="robots" content="index, follow" />
+        <meta property="og:title" content={metadata.openGraph.title.default} />
+        <meta property="og:description" content={metadata.openGraph.description} />
+        <meta property="og:url" content={metadata.metadataBase.href} />
+        <meta property="og:type" content={metadata.openGraph.type} />
+        <meta property="og:locale" content={metadata.openGraph.locale} />
+        <meta property="og:site_name" content={metadata.openGraph.siteName} />
+        <meta property="og:image" content={`${metadata.metadataBase.href}${metadata.openGraph.images[0].url}`} />
+        <meta property="og:image:alt" content={metadata.openGraph.images[0].alt} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={metadata.twitter.title.default} />
+        <meta name="twitter:description" content={metadata.twitter.description} />
+        <meta name="twitter:image" content={`${metadata.metadataBase.href}${metadata.twitter.images[0].url}`} />
+        <meta name="twitter:image:alt" content={metadata.twitter.images[0].alt} />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/react-toastify/dist/ReactToastify.min.css" />
+        <link rel="stylesheet" href="../globals.css" />
+      </Head>
       <body>
         <NextIntlClientProvider messages={messages}>
           <AuthSession>

--- a/src/dictionaries/ch.json
+++ b/src/dictionaries/ch.json
@@ -520,8 +520,7 @@
   },
   "withdraw": {
     "withdrawComplete": "会员退出已完成。",
-    "thankYouPartOne": "感谢您使用AightNow。",
-    "thankYouPartTwo": "我们将继续努力，不断发展。"
+    "thankYouMessage": "感谢您使用AightNow。\n我们将继续努力，不断发展。"
   },
   "button": {
     "change": "更改",

--- a/src/dictionaries/ch.json
+++ b/src/dictionaries/ch.json
@@ -314,7 +314,20 @@
     "preferOtherService": "偏好其他服务",
     "lowUsage": "使用频率低",
     "contentDissatisfaction": "对内容不满",
-    "otherReason": "其他"
+    "otherReason": "其他",
+    "metadata":{
+      "title": "我的页面",
+      "description": "用户可以管理个人设置和信息的我的页面。轻松管理个人设置和信息。",
+      "keywords": "我的页面, 语言设置, 个人信息修改, 个人信息, 资料, 注销账户, 注销, 使用条款, 条款",
+      "openGraph": {
+        "title": "我的页面",
+        "description": "用户可以管理个人设置和信息的我的页面。轻松管理个人设置和信息。"
+      },
+      "twitter": {
+        "title": "我的页面",
+        "description": "用户可以管理个人设置和信息的我的页面。轻松管理个人设置和信息。"
+      }
+    }
   },
   "lang": {
     "korean": "韩语",

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -314,7 +314,20 @@
     "preferOtherService": "Prefer another service",
     "lowUsage": "Low usage frequency",
     "contentDissatisfaction": "Dissatisfied with content",
-    "otherReason": "Other"
+    "otherReason": "Other",
+    "metadata": {
+      "title": "Ma Page",
+      "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page.",
+      "keywords": "Ma Page, paramètres de langue, modification des informations personnelles, informations personnelles, profil, suppression de compte, suppression, conditions d'utilisation, conditions",
+      "openGraph": {
+        "title": "Ma Page",
+        "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
+      },
+      "twitter": {
+        "title": "Ma Page",
+        "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
+      }
+    }
   },
   "lang": {
     "korean": "Korean",

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -316,16 +316,16 @@
     "contentDissatisfaction": "Dissatisfied with content",
     "otherReason": "Other",
     "metadata": {
-      "title": "Ma Page",
-      "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page.",
-      "keywords": "Ma Page, paramètres de langue, modification des informations personnelles, informations personnelles, profil, suppression de compte, suppression, conditions d'utilisation, conditions",
+      "title": "My Page",
+      "description": "Manage your personal settings and information easily on My Page.",
+      "keywords": "My Page, language settings, personal information edit, personal information, profile, account deletion, deletion, terms of service, terms",
       "openGraph": {
-        "title": "Ma Page",
-        "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
+        "title": "My Page",
+        "description": "Manage your personal settings and information easily on My Page."
       },
       "twitter": {
-        "title": "Ma Page",
-        "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
+        "title": "My Page",
+        "description": "Manage your personal settings and information easily on My Page."
       }
     }
   },

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -426,8 +426,7 @@
   },
   "withdraw": {
     "withdrawComplete": "Withdrawal complete.",
-    "thankYouPartOne": "Thank you for using AightNow.",
-    "thankYouPartTwo": "We will continue to strive and evolve."
+    "thankYouMessage": "Thank you for using AightNow.\nWe will continue to strive and evolve."
   },
   "investPropensity": {
     "title": "Investment Propensity Diagnosis",

--- a/src/dictionaries/fr.json
+++ b/src/dictionaries/fr.json
@@ -426,8 +426,7 @@
   },
   "withdraw": {
     "withdrawComplete": "Désinscription terminée.",
-    "thankYouPartOne": "Merci d'avoir utilisé AightNow.",
-    "thankYouPartTwo": "Nous continuerons à nous efforcer et à évoluer."
+    "thankYouMessage": "Merci d'avoir utilisé AightNow.\nNous continuerons à nous efforcer et à évoluer."
   },
   "investPropensity": {
     "title": "Diagnostic de Propension à l'Investissement",

--- a/src/dictionaries/fr.json
+++ b/src/dictionaries/fr.json
@@ -316,19 +316,18 @@
     "contentDissatisfaction": "Insatisfaction concernant le contenu",
     "otherReason": "Autre",
     "metadata":{
-  "title": "Ma Page",
-  "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page.",
-  "keywords": "Ma Page, paramètres de langue, modification des informations personnelles, informations personnelles, profil, suppression de compte, suppression, conditions d'utilisation, conditions",
-  "openGraph": {
-    "title": "Ma Page",
-    "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
-  },
-  "twitter": {
-    "title": "Ma Page",
-    "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
-  }
-}
-
+      "title": "Ma Page",
+      "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page.",
+      "keywords": "Ma Page, paramètres de langue, modification des informations personnelles, informations personnelles, profil, suppression de compte, suppression, conditions d'utilisation, conditions",
+      "openGraph": {
+        "title": "Ma Page",
+        "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
+      },
+      "twitter": {
+        "title": "Ma Page",
+        "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
+      }
+    }
   },
   "lang": {
     "korean": "Coréen",

--- a/src/dictionaries/fr.json
+++ b/src/dictionaries/fr.json
@@ -314,7 +314,21 @@
     "preferOtherService": "Préférer un autre service",
     "lowUsage": "Fréquence d'utilisation faible",
     "contentDissatisfaction": "Insatisfaction concernant le contenu",
-    "otherReason": "Autre"
+    "otherReason": "Autre",
+    "metadata":{
+  "title": "Ma Page",
+  "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page.",
+  "keywords": "Ma Page, paramètres de langue, modification des informations personnelles, informations personnelles, profil, suppression de compte, suppression, conditions d'utilisation, conditions",
+  "openGraph": {
+    "title": "Ma Page",
+    "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
+  },
+  "twitter": {
+    "title": "Ma Page",
+    "description": "Gérez facilement vos paramètres personnels et vos informations sur Ma Page."
+  }
+}
+
   },
   "lang": {
     "korean": "Coréen",

--- a/src/dictionaries/jp.json
+++ b/src/dictionaries/jp.json
@@ -426,8 +426,7 @@
   },
   "withdraw": {
     "withdrawComplete": "会員脱退が完了しました。",
-    "thankYouPartOne": "AightNowをご利用いただきありがとうございます。",
-    "thankYouPartTwo": "さらに努力して進化するAightNowになります。"
+    "thankYouMessage": "AightNowをご利用いただきありがとうございます。\nさらに努力して進化するAightNowになります。"
   },
   "investPropensity": {
     "title": "投資性向診断",

--- a/src/dictionaries/jp.json
+++ b/src/dictionaries/jp.json
@@ -315,20 +315,19 @@
     "lowUsage": "使用頻度が低い",
     "contentDissatisfaction": "コンテンツに不満",
     "otherReason": "その他",
-    "metadata":{
-  "title": "我的页面",
-  "description": "用户可以管理个人设置和信息的我的页面。轻松管理个人设置和信息。",
-  "keywords": "我的页面, 语言设置, 个人信息修改, 个人信息, 资料, 注销账户, 注销, 使用条款, 条款",
-  "openGraph": {
-    "title": "我的页面",
-    "description": "用户可以管理个人设置和信息的我的页面。轻松管理个人设置和信息。"
-  },
-  "twitter": {
-    "title": "我的页面",
-    "description": "用户可以管理个人设置和信息的我的页面。轻松管理个人设置和信息。"
-  }
-}
-
+    "metadata": {
+      "title": "マイページ",
+      "description": "マイページで個人設定と情報を簡単に管理できます。",
+      "keywords": "マイページ, 言語設定, 個人情報編集, 個人情報, プロフィール, アカウント削除, 削除, 利用規約, 規約",
+      "openGraph": {
+        "title": "マイページ",
+        "description": "マイページで個人設定と情報を簡単に管理できます。"
+      },
+      "twitter": {
+        "title": "マイページ",
+        "description": "マイページで個人設定と情報を簡単に管理できます。"
+      }
+    }
   },
   "lang": {
     "korean": "韓国語",

--- a/src/dictionaries/jp.json
+++ b/src/dictionaries/jp.json
@@ -314,7 +314,21 @@
     "preferOtherService": "他のサービスの方が良い",
     "lowUsage": "使用頻度が低い",
     "contentDissatisfaction": "コンテンツに不満",
-    "otherReason": "その他"
+    "otherReason": "その他",
+    "metadata":{
+  "title": "我的页面",
+  "description": "用户可以管理个人设置和信息的我的页面。轻松管理个人设置和信息。",
+  "keywords": "我的页面, 语言设置, 个人信息修改, 个人信息, 资料, 注销账户, 注销, 使用条款, 条款",
+  "openGraph": {
+    "title": "我的页面",
+    "description": "用户可以管理个人设置和信息的我的页面。轻松管理个人设置和信息。"
+  },
+  "twitter": {
+    "title": "我的页面",
+    "description": "用户可以管理个人设置和信息的我的页面。轻松管理个人设置和信息。"
+  }
+}
+
   },
   "lang": {
     "korean": "韓国語",

--- a/src/dictionaries/ko.json
+++ b/src/dictionaries/ko.json
@@ -425,8 +425,7 @@
   },
   "withdraw": {
     "withdrawComplete": "회원탈퇴가 완료되었습니다.",
-    "thankYouPartOne": "아잇나우를 이용해주셔서 감사합니다.",
-    "thankYouPartTwo": "더욱 더 노력하고 발전하는 아잇나우가 되겠습니다."
+    "thankYouMessage": "아잇나우를 이용해주셔서 감사합니다.\n더욱 더 노력하고 발전하는 아잇나우가 되겠습니다."
   },
   "investPropensity": {
     "title": "투자 성향 진단",

--- a/src/dictionaries/ko.json
+++ b/src/dictionaries/ko.json
@@ -310,7 +310,20 @@
     "preferOtherService": "다른 서비스가 더 좋아서",
     "lowUsage": "사용 빈도가 낮아서",
     "contentDissatisfaction": "콘텐츠 불만",
-    "otherReason": "기타"
+    "otherReason": "기타",
+    "metadata": {
+      "title": "마이페이지",
+      "description": "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요.",
+      "keywords": "마이페이지, 언어 설정, 개인정보 수정, 개인정보, 프로필, 회원탈퇴, 탈퇴, 이용약관, 약관",
+      "openGraph": {
+        "title": "마이페이지",
+        "description": "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
+      },
+      "twitter": {
+        "title": "마이페이지",
+        "description": "사용자의 개인 설정과 정보를 관리할 수 있는 마이 페이지입니다. 개인 설정과 정보를 쉽게 관리하세요."
+      }
+    }
   },
   "lang": {
     "korean": "한국어",


### PR DESCRIPTION
## 📌 기능 설명

- [x] 마이페이지 메타 태그 추가

## 📌 구현 내용

- 마이페이지 레이아웃에 메타 데이터를 추가하였습니다. 

## 📌 구현 결과

![image](https://github.com/user-attachments/assets/ca6134ae-f755-48f0-b279-33c0d7578b98)


## 📌 논의하고 싶은 점
- 루트 레이아웃 메타태그는 정민님이 먼저 작업해주셔서 삭제했습니다!🤩