### PR TITLE
[QJ5-177] 로그인/회원가입 메타데이터 타이틀 적용되지 않는 이슈 

### DIFF
--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -3,21 +3,15 @@ import { getTranslations } from "next-intl/server";
 export async function commonAuthMetadata(page: string) {
   const t = await getTranslations("auth");
   return {
-    title: {
-      template: t(`title.${page}`),
-    },
+    title: t(`title.${page}`),
     description: t(`metadata.${page}.description`),
     keywords: t(`metadata.${page}.description`),
     openGraph: {
-      title: {
-        template: t(`title.${page}`),
-      },
+      title: t(`title.${page}`),
       description: t(`metadata.${page}.description`),
     },
     twitter: {
-      title: {
-        template: t(`title.${page}`),
-      },
+      title: t(`title.${page}`),
       description: t(`metadata.${page}.description`),
     },
   };


### PR DESCRIPTION
## 📌 기능 설명


- [x] 배포된 사이트를 통해 찾은 이슈입니다. 잘못코드가 적용되어 메타태그의 타이들이 적용되고 있지 않는 이슈 

## 📌 구현 내용


## 📌 구현 결과

- 로그인/회원가입 메타태그의 타이틀 적용되지 않아, URL로 노출 중 
<img width="1440" alt="스크린샷 2024-07-31 오후 7 04 56" src="https://github.com/user-attachments/assets/a8895977-7852-4595-98b5-1c7f8e880bfe">


## 📌 논의하고 싶은 점

