### PR TITLE
[QJ5-178] 프로필 설정 프로필 설정 배포 이슈

### DIFF
--- a/src/app/[lang]/(auth)/account/profile-setup/page.tsx
+++ b/src/app/[lang]/(auth)/account/profile-setup/page.tsx
@@ -11,7 +11,6 @@ import ProfileSetUpForm from "../../_components/ProfileSetUpForm";
 import Loading from "../../_components/Loading";
 
 import { HOME_PATH, PROFILE_SETUP_PATH } from "@/routes/path";
-import { unstable_setRequestLocale } from "next-intl/server";
 
 export default function ProfileSetup() {
   const { data: session, status } = useSession();

--- a/src/app/[lang]/(auth)/account/profile-setup/page.tsx
+++ b/src/app/[lang]/(auth)/account/profile-setup/page.tsx
@@ -13,8 +13,7 @@ import Loading from "../../_components/Loading";
 import { HOME_PATH, PROFILE_SETUP_PATH } from "@/routes/path";
 import { unstable_setRequestLocale } from "next-intl/server";
 
-export default function ProfileSetup({ params }: { params: { lang: string } }) {
-  unstable_setRequestLocale(params.lang);
+export default function ProfileSetup() {
   const { data: session, status } = useSession();
   const t = useTranslations("auth");
 

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,17 +1,24 @@
 import { getTranslations } from "next-intl/server";
 
+// auth 관련 메타데이터
 export async function commonAuthMetadata(page: string) {
   const t = await getTranslations("auth");
+  const root = await getTranslations("metadata");
+  const siteName = root("root.siteName");
+
+  const title =
+    page === "register" || page === "profileSetup" ? `${t(`title.${page}`)} | ${siteName}` : t(`title.${page}`);
+
   return {
-    title: t(`title.${page}`),
+    title,
     description: t(`metadata.${page}.description`),
     keywords: t(`metadata.${page}.description`),
     openGraph: {
-      title: t(`title.${page}`),
+      title,
       description: t(`metadata.${page}.description`),
     },
     twitter: {
-      title: t(`title.${page}`),
+      title,
       description: t(`metadata.${page}.description`),
     },
   };


### PR DESCRIPTION


## 📌 기능 설명

- [x] 배포된 사이트내의 프로필 설정 페이지 오류 
- [x] 회원가입 관련 메타태그 타이틀 조건처리 

## 📌 구현 내용


## 📌 구현 결과

- 클라이언트 컴포넌트내의 unstable_setRequestLocale 제거 
<img width="1439" alt="스크린샷 2024-08-01 오전 12 16 04" src="https://github.com/user-attachments/assets/79107094-ac40-4a07-bd32-750bd1a9e67e">

- 회원가입 페이지 하위 라우터 아잇나우 문구 적용 
<img width="1438" alt="스크린샷 2024-08-01 오전 12 16 33" src="https://github.com/user-attachments/assets/27a6f915-8424-4219-8082-8a52d4092a09">


## 📌 논의하고 싶은 점

