### PR TITLE
[QJ5-186] not-found 페이지 다국어 작업

### DIFF
--- a/src/app/[lang]/not-found.tsx
+++ b/src/app/[lang]/not-found.tsx
@@ -15,7 +15,7 @@ export default function NotFound() {
     <section className="flex h-screen w-full items-center justify-center">
       <div className="flex max-w-[69rem] flex-col items-center gap-[1.6rem] rounded-[3.2rem] bg-white px-[8.2rem] py-[8.3rem]">
         <Image src="/icons/warning_icon.svg" alt="waring icon" width={64} height={64} />
-        <h4 className="heading_4 font-bold text-navy-900">{t("notFoundTitle")}</h4>
+        <h4 className="heading_4 font-bold text-navy-900 text-center">{t("notFoundTitle")}</h4>
         <span className="body_3 text-center font-medium text-navy-900 whitespace-pre-wrap">
           {t("notFoundDescription")}
         </span>

--- a/src/app/[lang]/not-found.tsx
+++ b/src/app/[lang]/not-found.tsx
@@ -5,26 +5,26 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/common";
 
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 
 export default function NotFound() {
+  const t = useTranslations("notFound");
   const router = useRouter();
 
   return (
     <section className="flex h-screen w-full items-center justify-center">
       <div className="flex max-w-[69rem] flex-col items-center gap-[1.6rem] rounded-[3.2rem] bg-white px-[8.2rem] py-[8.3rem]">
         <Image src="/icons/warning_icon.svg" alt="waring icon" width={64} height={64} />
-        <h4 className="heading_4 font-bold text-navy-900">요청하신 페이지를 찾을 수 없습니다.</h4>
-        <span className="body_3 text-center font-medium text-navy-900">
-          페이지의 주소가 잘못 입력되었거나
-          <br />
-          주소가 변경 혹은 삭제되어 요청하신 페이지를 찾을 수 없습니다.
+        <h4 className="heading_4 font-bold text-navy-900">{t("notFoundTitle")}</h4>
+        <span className="body_3 text-center font-medium text-navy-900 whitespace-pre-wrap">
+          {t("notFoundDescription")}
         </span>
         <Button
           className="px-[16.5rem] py-[1.8rem]"
           bgColor="bg-navy-900 body_3 mt-[1.6rem]"
           onClick={() => router.replace("/")}
         >
-          메인으로
+          {t("backToHome")}
         </Button>
       </div>
     </section>

--- a/src/dictionaries/ch.json
+++ b/src/dictionaries/ch.json
@@ -13,6 +13,11 @@
     "part3": "一起！",
     "message": "实时翻译的海外股票新闻和\n由AI分析师提供的难懂的海外股票报告"
   },
+  "notFound": {
+    "notFoundTitle": "找不到您请求的页面。",
+    "notFoundDescription": "您输入的页面地址有误，或者\n该地址已更改或删除，因此无法找到您请求的页面。",
+    "backToHome": "返回首页"
+  },
   "metadata": {
     "root": {
       "siteName": "AightNow",

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -320,6 +320,11 @@
     "part3": "!",
     "message": "Real-time translations of international stock news and\nDifficult international stock reports explained by AI analysts"
   },
+  "notFound": {
+    "notFoundTitle": "The page you requested cannot be found.",
+    "notFoundDescription": "The page address was entered incorrectly, or\nthe address has been changed or deleted, so the page you requested cannot be found.",
+    "backToHome": "Back to Home"
+  },
   "chatBot": {
     "initMessage": "Hello! I'm NowChatBot. How can I help you?",
     "linkComment": "Need analysis on this stock?",

--- a/src/dictionaries/fr.json
+++ b/src/dictionaries/fr.json
@@ -13,6 +13,11 @@
     "part3": "!",
     "message": "Traductions en temps réel des nouvelles sur les actions internationales et\nrapports internationaux difficiles expliqués par des analystes AI"
   },
+  "notFound": {
+    "notFoundTitle": "La page demandée est introuvable.",
+    "notFoundDescription": "L'adresse de la page a été mal saisie ou\nl'adresse a été modifiée ou supprimée, donc la page que vous avez demandée est introuvable.",
+    "backToHome": "Retour à l'accueil"
+  },
   "metadata": {
     "root": {
       "siteName": "AightNow",

--- a/src/dictionaries/jp.json
+++ b/src/dictionaries/jp.json
@@ -13,6 +13,11 @@
     "part3": "と一緒に！",
     "message": "海外株ニュースのリアルタイム翻訳と\nAIアナリストが教える難しい海外株レポート"
   },
+  "notFound": {
+    "notFoundTitle": "リクエストされたページが見つかりません。",
+    "notFoundDescription": "ページのアドレスが間違って入力されたか、\nアドレスが変更されたか削除されたため、リクエストされたページが見つかりません。",
+    "backToHome": "ホームへ戻る"
+  },
   "metadata": {
     "root": {
       "siteName": "AightNow",

--- a/src/dictionaries/ko.json
+++ b/src/dictionaries/ko.json
@@ -13,6 +13,11 @@
     "part3": "와 함께!",
     "message": "해외 주식 뉴스 실시간 번역과\nAI 애널리스트가 알려주는 어려운 해외주식 리포트"
   },
+  "notFound": {
+    "notFoundTitle": "요청하신 페이지를 찾을 수 없습니다.",
+    "notFoundDescription": "페이지의 주소가 잘못 입력되었거나\n주소가 변경 혹은 삭제되어 요청하신 페이지를 찾을 수 없습니다.",
+    "backToHome": "메인으로"
+  },
   "metadata": {
     "root": {
       "siteName": "아잇나우",


### PR DESCRIPTION
## 📌 기능 설명

- [x] not-found 페이지 다국어 작업

## 📌 구현 내용

- not-found 페이지의 다국어 작업을 진행했습니다.

## 📌 구현 결과

![image](https://github.com/user-attachments/assets/4192fb83-2841-456b-9064-6d13ab45e384)

## 📌 논의하고 싶은 점